### PR TITLE
Add rd inspect data-quality checks + per-frame provenance tags in convert/shardify

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the **[Installation guide](https://tri-ml.github.io/raiden/guide/installatio
 | `rd calibrate` | Calibrate cameras (hand-eye + scene extrinsics) |
 | `rd teleop` | Teleoperate arms without recording |
 | `rd record` | Record teleoperation demonstrations |
+| `rd inspect` | Check raw recordings for frame-stutter and blackouts |
 | `rd replay` | Replay recorded follower arm motion |
 | `rd console` | Browse and correct demonstration metadata in a terminal UI |
 | `rd convert` | Convert successful recordings to a structured dataset |

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -5,6 +5,7 @@
       members:
         - TeleopCommand
         - RecordCommand
+        - InspectCommand
         - ConvertCommand
         - VisualizeCommand
         - CalibrateCommand

--- a/docs/api/inspector.md
+++ b/docs/api/inspector.md
@@ -1,0 +1,3 @@
+# Inspector
+
+::: raiden.inspector

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -7,11 +7,12 @@
 3. **[Install software](installation.md)** - install Raiden and hardware SDKs.
 4. **[Calibrate cameras](calibration.md)** - hand-eye calibration for wrist cameras and static extrinsics for the scene camera.
 5. **[Record demonstrations](recording.md)** - capture teleoperation episodes with synchronized cameras and robot joint data.
-6. **[Convert to dataset](conversion.md)** - extract frames, synchronize multi-camera streams, and interpolate joint poses into a structured dataset.
-7. **[Shardify](shardify.md)** - export converted episodes to WebDataset sharded `.tar` files for policy training.
-8. **[Evaluation](serve.md)** - run the live policy inference server (chiral protocol).
-9. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
-10. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
+6. **[Inspect data quality](inspection.md)** - flag frame-stutter and black frames in raw recordings before converting.
+7. **[Convert to dataset](conversion.md)** - extract frames, synchronize multi-camera streams, and interpolate joint poses into a structured dataset.
+8. **[Shardify](shardify.md)** - export converted episodes to WebDataset sharded `.tar` files for policy training.
+9. **[Evaluation](serve.md)** - run the live policy inference server (chiral protocol).
+10. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
+11. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
 
 ## Commands
 
@@ -21,6 +22,7 @@
 | `rd calibrate` | Calibrate cameras (hand-eye + scene extrinsics) |
 | `rd teleop` | Teleoperate arms without recording |
 | `rd record` | Record teleoperation demonstrations |
+| `rd inspect` | Check raw recordings for frame-stutter and blackouts |
 | `rd convert` | Convert raw recordings to a structured dataset |
 | `rd shardify` | Export converted episodes to WebDataset shards |
 | `rd serve` | Start the chiral policy server for live inference |

--- a/docs/guide/inspection.md
+++ b/docs/guide/inspection.md
@@ -1,0 +1,113 @@
+# Data quality inspection
+
+The `rd inspect` command scans raw SVO2 recordings for **frame-stutter** and
+**left-eye blackouts** before you convert them, so silent capture problems are
+caught while they can still be re-recorded — not discovered as corrupt training
+data weeks later.
+
+## Usage
+
+```bash
+rd inspect
+```
+
+Running the command opens an interactive fzf selector over the task directories
+in `./data/raw/`. Use Tab to toggle individual tasks and Enter to confirm; each
+selected task is scanned and reported.
+
+Inspect a single task directory directly (skips the selector):
+
+```bash
+rd inspect --recording-dir data/raw/pick_cube
+```
+
+Point at a different data root, or force a full rescan ignoring the cache:
+
+```bash
+rd inspect --data-dir /mnt/storage/robot_data
+rd inspect --recording-dir data/raw/pick_cube --force
+```
+
+## Why inspect before converting
+
+Two capture faults are invisible in the recording verdict but corrupt the data
+downstream:
+
+- **Frame stutter.** [`rd replay`](replay.md) and the training pipeline treat the
+  surviving frames as a uniformly-spaced 30 Hz stream. If the camera dropped
+  frames during capture, the real time between two surviving frames collapses to
+  a single 1/30 s step — producing bursts of unphysically fast motion and
+  mislabelled actions. `rd inspect` measures the ratio of real elapsed duration
+  to the ideal 30 Hz duration (`shrink`) and the largest inter-frame gap.
+- **Black left eye.** [`rd convert`](conversion.md) writes the stereo **LEFT**
+  view to training RGB. A dropped left sensor produces uniformly black frames
+  that the timestamp scan cannot see, so the images are checked directly.
+
+The check runs on **every** `cameras/*.svo2` view (wrist cameras can drop frames
+independently of the scene camera) and is camera-name agnostic — any directory
+holding a `cameras/` folder with at least one `.svo2` file is treated as an
+episode.
+
+## Verdicts
+
+Each episode gets a single verdict — the **worst** of its per-camera views,
+escalated if a view is missing or has anomalously few frames.
+
+| Verdict | Meaning |
+|---|---|
+| `clean` | Steady 30 Hz, no meaningful gaps. Use as-is. |
+| `borderline` | Minor stutter (shrink > 1.05 or a gap > 200 ms). Still usable. |
+| `bad` | Noticeable stutter (shrink > 1.10 or a gap > 1 s). Inspect before training on it. |
+| `broken` | Severe stutter (shrink > 1.20, a gap > 2 s, or fewer than 10 frames). Re-record. |
+| `black` | More than 10 % of left-eye frames are black — the RGB is corrupt regardless of timing. Re-record. |
+| `missing` | A view present in other episodes is absent here, or a `.svo2` failed to open. |
+
+A view is additionally flagged `DROP` when its frame count is below 95 % of the
+busiest view in the same episode (cameras grab in lock-step, so a large
+discrepancy means one view lost frames).
+
+## What it checks
+
+For each view the scan reports:
+
+| Metric | Description |
+|---|---|
+| `n` | Frames actually decoded from the SVO2. |
+| `median` / `max` / `p99` (ms) | Inter-frame time gaps. `max` drives the timing verdict. |
+| `g>50` / `g>100` / `g>500` | Count of gaps exceeding 50 / 100 / 500 ms. |
+| `blk%` | Fraction of frames whose left eye is black. |
+| `shrink` | Real duration ÷ ideal 30 Hz duration. 1.00 = perfect; higher = dropped frames. |
+
+## Output
+
+Results are cached and aggregated so re-runs are cheap:
+
+```
+data/raw/<task>/
+    inspect_report.json         # task-level aggregate (rebuilt every run)
+    0000/
+        inspect.json            # per-camera cache, keyed by each .svo2 mtime
+        cameras/*.svo2
+    0001/
+        inspect.json
+        ...
+```
+
+Each camera's result is cached against its `.svo2` modification time, so a re-run
+only re-scans views whose file changed (or are new). Pass `--force` to ignore the
+cache entirely.
+
+`inspect_report.json` records the per-episode verdicts, the drop/missing views,
+the full per-view metrics, and the thresholds used — a machine-readable manifest
+you can gate conversion or export on.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--recording-dir` | *interactive* | Inspect one task directory directly instead of the fzf selector. |
+| `--data-dir` | `data` | Root data directory; the selector lists tasks under `<data_dir>/raw/`. |
+| `--force` | `False` | Ignore the per-episode `inspect.json` cache and rescan every view. |
+| `--workers` | `min(cpu, 8)` | Concurrent SVO2 scans. |
+
+Run `rd inspect --help` for the full list.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,11 +58,12 @@ nav:
     - "4. Calibration": guide/calibration.md
     - "5. Console": guide/console.md
     - "6. Recording": guide/recording.md
-    - "7. Conversion": guide/conversion.md
-    - "8. Shardify": guide/shardify.md
-    - "9. Evaluation": guide/serve.md
-    - "10. Replay": guide/replay.md
-    - "11. Visualization": guide/visualization.md
+    - "7. Data Quality Inspection": guide/inspection.md
+    - "8. Conversion": guide/conversion.md
+    - "9. Shardify": guide/shardify.md
+    - "10. Evaluation": guide/serve.md
+    - "11. Replay": guide/replay.md
+    - "12. Visualization": guide/visualization.md
     - Safety: guide/safety.md
     - FAQ: guide/faq.md
   - API Reference:
@@ -72,6 +73,7 @@ nav:
     - Camera Config: api/camera_config.md
     - Recorder: api/recorder.md
     - Converter: api/converter.md
+    - Inspector: api/inspector.md
     - Visualizer: api/visualizer.md
     - Calibration: api/calibration.md
 

--- a/raiden/cli.py
+++ b/raiden/cli.py
@@ -235,6 +235,29 @@ class ConvertCommand:
     reconvert: bool = False
     """Re-convert all successful demonstrations even if already marked as converted (default: False)"""
 
+    append: bool = False
+    """Number new episodes after the highest existing one and rebuild split_all.json (ignores the DB; adds newly recorded episodes without renumbering existing ones)"""
+
+    w_intervention: float = 1.0
+    """Per-sample loss weight written onto HG-DAgger human-takeover frames (control_source==1); 1.0 = no upweighting (default)"""
+
+
+@dataclass
+class InspectCommand:
+    """Inspect raw SVO2 recordings for frame-stutter and left-eye blackouts before converting"""
+
+    recording_dir: Optional[str] = None
+    """Path to a single raw task directory to inspect (default: interactive fzf selector over <data_dir>/raw)"""
+
+    data_dir: str = "data"
+    """Root data directory (default: ./data); the selector lists tasks under <data_dir>/raw/"""
+
+    force: bool = False
+    """Ignore the per-episode inspect.json cache and rescan every view (default: False)"""
+
+    workers: Optional[int] = None
+    """Concurrent SVO2 scans (default: min(cpu_count, 8))"""
+
 
 @dataclass
 class ReplayCommand:
@@ -340,6 +363,12 @@ class ShardifyCommand:
     use_depth: bool = False
     """Include depth images (.depth.png) in shards (default: False)"""
 
+    keep: Literal["all", "interventions", "interventions_context"] = "all"
+    """HG-DAgger subsetting by per-frame control_source: 'all' (every frame), 'interventions' (only human-takeover frames), or 'interventions_context' (interventions + the keep_context frames before each). Note: 'interventions*' yield ZERO samples on non-dagger data (default: all)"""
+
+    keep_context: int = 15
+    """Policy frames to retain before each intervention when keep=interventions_context (default: 15)"""
+
 
 @dataclass
 class ServeCommand:
@@ -403,6 +432,9 @@ def _print_help() -> None:
     print("  record                      Record teleoperation demonstrations")
     print(
         "  convert                     Convert SVO2/bag recordings to UnifiedDataset format"
+    )
+    print(
+        "  inspect                     Check raw recordings for frame-stutter and blackouts"
     )
     print("  replay                      Replay recorded follower arm motion")
     print("  visualize                   Visualize a converted recording with Rerun")
@@ -581,7 +613,24 @@ def main():
                     reconvert=command.reconvert,
                     processed_base=str(_Path(command.data_dir) / "processed"),
                     tri_stereo_variant=command.tri_stereo_variant,
+                    append=command.append,
+                    w_intervention=command.w_intervention,
                 )
+
+        elif subcommand == "inspect":
+            sys.argv.pop(1)
+            command = tyro.cli(
+                InspectCommand,
+                description="Inspect raw SVO2 recordings for frame-stutter and left-eye blackouts",
+            )
+            from raiden.inspector import run_inspect
+
+            run_inspect(
+                recording_dir=command.recording_dir,
+                data_dir=command.data_dir,
+                force=command.force,
+                workers=command.workers,
+            )
 
         elif subcommand == "visualize":
             sys.argv.pop(1)
@@ -641,6 +690,8 @@ def main():
                     num_workers=command.num_workers,
                     stats_stride=command.stats_stride,
                     use_depth=command.use_depth,
+                    keep=command.keep,
+                    keep_context=command.keep_context,
                 )
                 run_shardify(
                     episode_dirs,

--- a/raiden/converter.py
+++ b/raiden/converter.py
@@ -526,6 +526,24 @@ def _apply_camera_trim(
 # ---------------------------------------------------------------------------
 
 
+def _resample_flag_nearest(
+    flag_raw: np.ndarray, robot_ts: np.ndarray, ref_ts: np.ndarray
+) -> np.ndarray:
+    """Resample a discrete per-robot-frame flag onto the camera-frame grid by
+    NEAREST timestamp.
+
+    Used for ``control_source`` — a 0/1 human-takeover flag that must never be
+    linearly interpolated (``np.interp`` would smear it into a meaningless
+    fraction). For each camera timestamp we pick the robot sample whose timestamp
+    is closest, so the flag stays a clean 0/1.
+    """
+    flag_raw = np.asarray(flag_raw).reshape(-1)
+    ridx = np.clip(np.searchsorted(robot_ts, ref_ts), 1, len(robot_ts) - 1)
+    pick_left = np.abs(ref_ts - robot_ts[ridx - 1]) <= np.abs(ref_ts - robot_ts[ridx])
+    ridx = np.clip(np.where(pick_left, ridx - 1, ridx), 0, len(flag_raw) - 1)
+    return flag_raw[ridx].astype(np.int8)
+
+
 def _build_lowdim(
     seq_dir: Path,
     cameras: List[str],
@@ -538,6 +556,7 @@ def _build_lowdim(
     right_base_to_left_base: Optional[np.ndarray],
     cam_timestamps: Dict[str, Optional[np.ndarray]],
     wrist_camera_joint_keys: Optional[Dict[str, str]] = None,
+    w_intervention: float = 1.0,
 ) -> None:
     """Write seq_dir/lowdim.npz with all cameras' intrinsics/extrinsics plus joints, action, language.
 
@@ -556,6 +575,11 @@ def _build_lowdim(
                              [l_pos(3), l_rot9(9), l_gripper(1), r_pos(3), r_rot9(9), r_gripper(1)].
     ``language_task``        str  task name.
     ``language_prompt``      str  task instruction.
+    ``control_source``       int8  0 = policy drove this frame, 1 = human takeover
+                             (HG-DAgger). All-zero for ordinary teleop.
+    ``is_intervention``      bool  ``control_source == 1``.
+    ``sample_weight``        float32  per-sample loss weight; ``w_intervention`` on
+                             human-takeover frames, else 1.0.
     """
     _WALL_CLOCK_MIN_NS = 1_577_836_800_000_000_000
 
@@ -575,6 +599,11 @@ def _build_lowdim(
                 break
 
     robot_ts: Optional[np.ndarray] = None
+    # True only when ref_ts and robot_ts share the same camera-SDK nanosecond
+    # clock (the normal path). The recovery tags below are resampled by nearest
+    # timestamp, so they are only meaningful when the two grids are comparable;
+    # on the legacy linspace fallback we leave the tags at their defaults.
+    ts_aligned = False
     if robot_data is not None and n_frames > 0:
         robot_ts_raw = robot_data.get("timestamps")
         if (
@@ -583,6 +612,7 @@ def _build_lowdim(
             and robot_ts_raw.dtype == np.int64
         ):
             robot_ts = robot_ts_raw.astype(np.float64)
+            ts_aligned = True
         else:
             # Legacy: uniform linspace over the recording duration.
             duration = rec_meta.get("duration_s", 1.0)
@@ -812,6 +842,27 @@ def _build_lowdim(
     language_task = np.array(rec_meta.get("task_name", ""), dtype=object)
     language_prompt = np.array(rec_meta.get("task_instruction", ""), dtype=object)
 
+    # ── recovery-data provenance tags (HG-DAgger) ─────────────────────────
+    # Resample the per-robot-frame control_source flag onto the camera grid by
+    # NEAREST NEIGHBOUR — never np.interp, which would smear the discrete 0/1
+    # takeover flag into a meaningless fraction. Ordinary teleop recordings have
+    # no control_source key, so every frame defaults to policy/weight-1.0 and the
+    # tags are a harmless, uniform addition to the schema.
+    control_source = np.zeros(n_frames, dtype=np.int8)
+    is_intervention = np.zeros(n_frames, dtype=bool)
+    sample_weight = np.ones(n_frames, dtype=np.float32)
+    cs_raw = robot_data.get("control_source") if robot_data is not None else None
+    if (
+        cs_raw is not None
+        and ts_aligned
+        and robot_ts is not None
+        and ref_ts is not None
+        and len(robot_ts) >= 2
+    ):
+        control_source = _resample_flag_nearest(cs_raw, robot_ts, ref_ts)
+        is_intervention = control_source == 1
+        sample_weight[is_intervention] *= float(w_intervention)
+
     # ── write per-frame files into lowdim/ ────────────────────────────────
     lowdim_dir = seq_dir / "lowdim"
     lowdim_dir.mkdir(parents=True, exist_ok=True)
@@ -830,6 +881,9 @@ def _build_lowdim(
             frame_data["action_joints"] = action_joints[i]
         frame_data["language_task"] = language_task
         frame_data["language_prompt"] = language_prompt
+        frame_data["control_source"] = control_source[i]
+        frame_data["is_intervention"] = bool(is_intervention[i])
+        frame_data["sample_weight"] = sample_weight[i]
         if right_base_to_left_base is not None:
             frame_data["T_left_from_right"] = right_base_to_left_base
         with open(lowdim_dir / f"{i:010d}.pkl", "wb") as f:
@@ -883,6 +937,11 @@ def _build_sequence_metadata(
         "extrinsics": {"transform": "cam2world", "metric": True},
         "action": {"format": "joint_cmd", "dims": 14},
         "control": rec_meta.get("control", "leader"),
+        # Recovery-data provenance carried raw → converted so shardify can build
+        # the ABC 80:10:10 base/intervention mix. Defaults keep ordinary demos as
+        # plain teleop episodes.
+        "episode_kind": rec_meta.get("episode_kind", "teleop"),
+        "intervention_ratio": rec_meta.get("intervention_ratio"),
     }
 
     with open(seq_dir / "metadata.json", "w") as f:
@@ -957,6 +1016,7 @@ def convert_recording(
     ffs_iters: int = 8,
     tri_stereo_variant: str = "c64",
     reconvert: bool = False,
+    w_intervention: float = 1.0,
 ) -> Dict[str, int]:
     """Convert a recording directory to UnifiedDataset format.
 
@@ -1197,6 +1257,7 @@ def convert_recording(
         right_base_to_left_base=T_left_base_from_right_base,
         cam_timestamps=cam_timestamps,
         wrist_camera_joint_keys=wrist_camera_joint_keys,
+        w_intervention=w_intervention,
     )
     print(f"  ✓ lowdim/ ({n_min} frames)")
 
@@ -1239,6 +1300,8 @@ def convert_task(
     reconvert: bool = False,
     processed_base: Optional[str] = None,
     tri_stereo_variant: str = "c64",
+    append: bool = False,
+    w_intervention: float = 1.0,
 ) -> None:
     """Convert all recordings in a task directory into a single UnifiedDataset.
 
@@ -1288,45 +1351,67 @@ def convert_task(
     except Exception:
         _db = None
 
-    # Filter recordings: skip failures/pending, and (unless reconvert) already
-    # converted ones.  Recordings with no DB entry are treated as unknown and
-    # included so directories recorded before the DB was set up are not dropped.
-    success_dirs = []
-    skipped = 0
-    for rec_dir in recording_dirs:
-        status = "unknown"
-        already_converted = False
-        if _db is not None:
-            try:
-                demo = _db.get_demonstration_by_raw_path(str(rec_dir))
-                if demo is not None:
-                    status = demo.get("status", "pending")
-                    already_converted = bool(demo.get("converted", False))
-            except Exception:
-                pass
-        if status not in ("success", "unknown"):
-            print(f"  Skipping {rec_dir.name} (status={status})")
-            skipped += 1
-        elif already_converted and not reconvert:
-            print(
-                f"  Skipping {rec_dir.name} (already converted, use --reconvert to force)"
-            )
-            skipped += 1
-        else:
-            success_dirs.append(rec_dir)
+    # ── select recordings + choose the starting episode number ────────────
+    # Default: renumber episodes 0000.. from scratch, DB-filtered.
+    # --append: number new episodes after the highest existing one and ignore
+    # the DB (so freshly added recordings extend the dataset instead of clobbering
+    # or renumbering the episodes already on disk).
+    if append:
+        success_dirs = [
+            d for d in recording_dirs if any((d / "cameras").glob("*.svo2"))
+        ]
+        existing_nums = [
+            int(p.name) for p in out_base.iterdir() if p.is_dir() and p.name.isdigit()
+        ]
+        append_start = (max(existing_nums) + 1) if existing_nums else 0
+        if not success_dirs:
+            print("No recordings with SVO2 files to append.")
+            return
+        print(
+            f"Appending {len(success_dirs)} recording(s) starting at "
+            f"episode {append_start:04d}\n"
+        )
+    else:
+        # Filter recordings: skip failures/pending, and (unless reconvert) already
+        # converted ones.  Recordings with no DB entry are treated as unknown and
+        # included so directories recorded before the DB was set up are not dropped.
+        append_start = 0
+        success_dirs = []
+        skipped = 0
+        for rec_dir in recording_dirs:
+            status = "unknown"
+            already_converted = False
+            if _db is not None:
+                try:
+                    demo = _db.get_demonstration_by_raw_path(str(rec_dir))
+                    if demo is not None:
+                        status = demo.get("status", "pending")
+                        already_converted = bool(demo.get("converted", False))
+                except Exception:
+                    pass
+            if status not in ("success", "unknown"):
+                print(f"  Skipping {rec_dir.name} (status={status})")
+                skipped += 1
+            elif already_converted and not reconvert:
+                print(
+                    f"  Skipping {rec_dir.name} (already converted, use --reconvert to force)"
+                )
+                skipped += 1
+            else:
+                success_dirs.append(rec_dir)
 
-    if skipped:
-        print(f"\nSkipped {skipped} non-success recording(s).")
-    if not success_dirs:
-        print("No successful recordings to convert.")
-        return
+        if skipped:
+            print(f"\nSkipped {skipped} non-success recording(s).")
+        if not success_dirs:
+            print("No successful recordings to convert.")
+            return
 
-    print(f"Converting {len(success_dirs)} successful recording(s)\n")
+        print(f"Converting {len(success_dirs)} successful recording(s)\n")
 
-    for i, rec_dir in enumerate(success_dirs):
-        episode_name = f"{i:04d}"
+    for offset, rec_dir in enumerate(success_dirs):
+        episode_name = f"{append_start + offset:04d}"
         ep_dir = out_base / episode_name
-        print(f"[{i + 1}/{len(success_dirs)}] {rec_dir.name} → {episode_name}/")
+        print(f"[{offset + 1}/{len(success_dirs)}] {rec_dir.name} → {episode_name}/")
         counts = convert_recording(
             str(rec_dir),
             episode_dir=str(ep_dir),
@@ -1335,6 +1420,7 @@ def convert_task(
             ffs_iters=ffs_iters,
             tri_stereo_variant=tri_stereo_variant,
             reconvert=reconvert,
+            w_intervention=w_intervention,
         )
 
         if counts:
@@ -1363,6 +1449,20 @@ def convert_task(
                 pass
 
     # ── combined split_all.json ────────────────────────────────────────────
+    # When appending, the split must span the whole dataset on disk (existing +
+    # newly appended episodes), not just the ones converted this run.
+    if append:
+        episode_frame_counts = {}
+        for p in sorted(out_base.iterdir()):
+            if not (p.is_dir() and p.name.isdigit()):
+                continue
+            meta_file = p / "metadata.json"
+            n_frames = 0
+            if meta_file.exists():
+                with open(meta_file) as f:
+                    n_frames = json.load(f).get("num_frames", 0)
+            episode_frame_counts[p.name] = n_frames
+
     total_frames = sum(episode_frame_counts.values())
     n_eps = len(episode_frame_counts)
     split = {

--- a/raiden/inspector.py
+++ b/raiden/inspector.py
@@ -1,0 +1,549 @@
+"""Pre-flight quality check for raw SVO2 recordings — flag frame-stutter and
+left-eye blackouts before ``rd convert``.
+
+Reads each frame's capture timestamp from every ``cameras/*.svo2`` file and, for
+the stereo LEFT view only, checks whether the frame is fully black.  The LEFT
+view is the one ``rd convert`` turns into training RGB
+(:meth:`raiden.cameras.zed.ZedCamera.get_frame` retrieves ``sl.VIEW.LEFT``), so a
+black left eye corrupts the data even when the right eye and frame timing are
+perfectly healthy — a failure the timestamp scan alone cannot see.
+
+Stutter matters because :func:`raiden.robot.replay._solve_ik_sequence` treats
+processed lowdim files as uniformly-spaced 30 Hz keyframes (``np.arange``-based
+indexing).  Any real-time gap between consecutive surviving frames therefore
+collapses to a single 1/30 s replay step, producing visible bursts of
+unphysical speed during ``rd replay`` and silently distorting the action labels
+a policy learns from.
+
+All camera views (``cameras/*.svo2`` — e.g. ``scene_camera``,
+``left_wrist_camera``, ``right_wrist_camera``) of each episode are scanned, since
+wrist cameras sometimes drop or lose frames independently of the scene camera.
+The views of one episode are scanned concurrently (one thread per view).  The
+check is camera-name agnostic: any directory containing a ``cameras/`` folder
+with at least one ``.svo2`` file is treated as an episode.
+
+Caching
+-------
+Each scanned episode gets its own ``<episode_dir>/inspect.json`` cache file
+holding one entry per camera, each keyed by that camera's SVO2 mtime.  Re-runs
+only re-scan the views whose ``.svo2`` has changed since the cache was written
+(or are missing from the cache entirely).  The task-level
+``<task_dir>/inspect_report.json`` is a derived aggregate, rebuilt from the
+per-episode files on every run.
+"""
+
+import concurrent.futures
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# ── verdict thresholds ────────────────────────────────────────────────────────
+# ``shrink`` = real elapsed duration / ideal 30 Hz replay duration.  A value of
+# 1.0 means the recording ran at exactly 30 Hz; larger means frames were dropped
+# and the surviving ones will play back too fast.
+CLEAN_SHRINK = 1.05
+BORDERLINE_SHRINK = 1.10
+BAD_SHRINK = 1.20
+CLEAN_MAX_DT_MS = 200.0
+BORDERLINE_MAX_DT_MS = 1000.0
+BAD_MAX_DT_MS = 2000.0
+MIN_FRAMES = 10
+
+# A view whose frame count falls below this fraction of the episode's busiest
+# view is flagged as having dropped/missing frames (cameras grab in lock-step at
+# 30 Hz, so a large discrepancy means one view lost frames).
+FRAME_DROP_RATIO = 0.95
+
+# Left-eye blackout detection. A frame is "black" when its MEAN brightness across
+# the RGB channels is at/below BLACK_MEAN_MAX. A dead left eye (sensor dropout)
+# sits uniformly at the noise floor (~3/255), while even a dim real scene means in
+# the tens-to-hundreds — a ~25x separation. We use the mean, not the per-pixel
+# max: a visually-black frame still carries read noise and stray hot pixels whose
+# raw channel values routinely exceed any low cutoff, so a max-based test silently
+# misses real blackouts. A view is flagged once more than BLACK_RATIO of its
+# frames are black.
+BLACK_MEAN_MAX = 10.0
+BLACK_RATIO = 0.10
+
+# The LEFT view is retrieved downscaled to this resolution purely to measure mean
+# brightness. A black frame is black at any resolution, so downscaling keeps the
+# per-frame check on EVERY frame (no temporal sampling — a blackout starting
+# anywhere is caught) while cutting its cost ~8x: full-res adds ~190% to the scan,
+# this adds ~25%, since the unavoidable per-frame ``grab`` decode dominates.
+BLACK_CHECK_WIDTH = 320
+BLACK_CHECK_HEIGHT = 180
+
+VERDICT_RANK = {
+    "clean": 0,
+    "borderline": 1,
+    "bad": 2,
+    "broken": 3,
+    "black": 4,
+    "missing": 5,
+}
+
+EPISODE_CACHE_NAME = "inspect.json"
+TASK_REPORT_NAME = "inspect_report.json"
+
+# Default concurrent SVO2 scans. Each scan is a decode loop that releases the GIL
+# during ``grab``, but the ZED SDK saturates around 8 concurrent decodes (more
+# threads only open extra cameras for no throughput gain), so cap the default
+# there. Override with ``--workers`` for unusual hardware.
+DEFAULT_SCAN_WORKERS = 8
+
+
+def _default_workers() -> int:
+    return min(os.cpu_count() or 4, DEFAULT_SCAN_WORKERS)
+
+
+def _is_episode_dir(d: Path) -> bool:
+    """An episode is any directory holding a ``cameras/`` folder with ≥1 ``.svo2``."""
+    cam_dir = d / "cameras"
+    return d.is_dir() and cam_dir.is_dir() and any(cam_dir.glob("*.svo2"))
+
+
+@dataclass
+class InspectResult:
+    n_frames: int
+    sdk_total_frames: int
+    n_grab_errors: int
+    n_black_frames: int
+    black_ratio: float
+    median_dt_ms: float
+    mean_dt_ms: float
+    max_dt_ms: float
+    p99_dt_ms: float
+    gaps_over_50ms: int
+    gaps_over_100ms: int
+    gaps_over_500ms: int
+    real_duration_s: float
+    replay_duration_s: float
+    shrink: float
+    worst_burst_at_replay_s: float
+    verdict: str
+    svo2_mtime_ns: int
+
+
+def _scan_svo2(svo_path: Path) -> Tuple[np.ndarray, int, int, int]:
+    """Walk an SVO2 file, collecting per-frame timestamps and left-eye blackouts.
+
+    Returns ``(timestamps_ns, sdk_total_frames, n_grab_errors, n_black_frames)``.
+    ``n_black_frames`` counts frames whose stereo LEFT view — the eye
+    ``rd convert`` writes to training RGB — is black (mean RGB brightness
+    ``<= BLACK_MEAN_MAX``).  ``pyzed`` is imported lazily so ``rd inspect
+    --help`` works on machines without the SDK.
+    """
+    import pyzed.sl as sl
+
+    cam = sl.Camera()
+    init = sl.InitParameters()
+    init.set_from_svo_file(str(svo_path))
+    init.svo_real_time_mode = False
+    init.depth_mode = sl.DEPTH_MODE.NONE
+    init.coordinate_units = sl.UNIT.METER
+    # We read frame timestamps and the LEFT image only — skip depth (above),
+    # self-calibration and sensor ingest to cut per-file overhead (matters when
+    # scanning hundreds of episodes).
+    init.camera_disable_self_calib = True
+    init.sensors_required = False
+
+    err = cam.open(init)
+    if err != sl.ERROR_CODE.SUCCESS:
+        raise RuntimeError(f"Failed to open {svo_path}: {err}")
+
+    sdk_total = cam.get_svo_number_of_frames()
+    runtime = sl.RuntimeParameters()
+    left = sl.Mat()
+    low_res = sl.Resolution(BLACK_CHECK_WIDTH, BLACK_CHECK_HEIGHT)
+    ts: List[int] = []
+    n_errors = 0
+    n_black = 0
+    try:
+        while True:
+            err = cam.grab(runtime)
+            if err == sl.ERROR_CODE.END_OF_SVOFILE_REACHED:
+                break
+            if err != sl.ERROR_CODE.SUCCESS:
+                n_errors += 1
+                continue
+            ts.append(cam.get_timestamp(sl.TIME_REFERENCE.IMAGE).get_nanoseconds())
+            # Same eye convert uses (VIEW.LEFT), downscaled — RGB channels only
+            # (get_data() is H x W x 4 BGRA; drop alpha).
+            cam.retrieve_image(left, sl.VIEW.LEFT, sl.MEM.CPU, low_res)
+            if left.get_data()[:, :, :3].mean() <= BLACK_MEAN_MAX:
+                n_black += 1
+    finally:
+        left.free()
+        cam.close()
+
+    return np.asarray(ts, dtype=np.int64), int(sdk_total), n_errors, n_black
+
+
+def _classify(shrink: float, max_dt_ms: float, n_frames: int) -> str:
+    if n_frames < MIN_FRAMES or shrink > BAD_SHRINK or max_dt_ms > BAD_MAX_DT_MS:
+        return "broken"
+    if shrink > BORDERLINE_SHRINK or max_dt_ms > BORDERLINE_MAX_DT_MS:
+        return "bad"
+    if shrink > CLEAN_SHRINK or max_dt_ms > CLEAN_MAX_DT_MS:
+        return "borderline"
+    return "clean"
+
+
+def _result_from_scan(
+    ts: np.ndarray,
+    sdk_total: int,
+    n_errors: int,
+    n_black: int,
+    svo_mtime_ns: int,
+) -> InspectResult:
+    """Turn a raw SVO2 scan into a classified :class:`InspectResult`.
+
+    Split out from :func:`_analyze_svo` so the (pure) classification maths can be
+    unit-tested without the ZED SDK.
+    """
+    n = len(ts)
+    if n < 2:
+        return InspectResult(
+            n_frames=n,
+            sdk_total_frames=sdk_total,
+            n_grab_errors=n_errors,
+            n_black_frames=n_black,
+            black_ratio=float(n_black / n) if n else 0.0,
+            median_dt_ms=0.0,
+            mean_dt_ms=0.0,
+            max_dt_ms=0.0,
+            p99_dt_ms=0.0,
+            gaps_over_50ms=0,
+            gaps_over_100ms=0,
+            gaps_over_500ms=0,
+            real_duration_s=0.0,
+            replay_duration_s=0.0,
+            shrink=0.0,
+            worst_burst_at_replay_s=0.0,
+            verdict="broken",
+            svo2_mtime_ns=svo_mtime_ns,
+        )
+
+    dt_ms = np.diff(ts) / 1e6
+    real_s = float((ts[-1] - ts[0]) / 1e9)
+    replay_s = (n - 1) / 30.0
+    shrink = real_s / replay_s if replay_s > 0 else 0.0
+    max_dt = float(dt_ms.max())
+    black_ratio = n_black / n
+
+    # A black left eye corrupts the training data outright, so it overrides the
+    # (orthogonal) timing verdict — the timing metrics stay in the result either
+    # way for diagnosis.
+    verdict = "black" if black_ratio > BLACK_RATIO else _classify(shrink, max_dt, n)
+
+    return InspectResult(
+        n_frames=n,
+        sdk_total_frames=sdk_total,
+        n_grab_errors=n_errors,
+        n_black_frames=n_black,
+        black_ratio=float(black_ratio),
+        median_dt_ms=float(np.median(dt_ms)),
+        mean_dt_ms=float(np.mean(dt_ms)),
+        max_dt_ms=max_dt,
+        p99_dt_ms=float(np.percentile(dt_ms, 99)),
+        gaps_over_50ms=int(np.sum(dt_ms > 50)),
+        gaps_over_100ms=int(np.sum(dt_ms > 100)),
+        gaps_over_500ms=int(np.sum(dt_ms > 500)),
+        real_duration_s=real_s,
+        replay_duration_s=replay_s,
+        shrink=float(shrink),
+        worst_burst_at_replay_s=float(int(dt_ms.argmax())) / 30.0,
+        verdict=verdict,
+        svo2_mtime_ns=svo_mtime_ns,
+    )
+
+
+def _analyze_svo(svo_path: Path) -> InspectResult:
+    svo_mtime_ns = svo_path.stat().st_mtime_ns
+    ts, sdk_total, n_errors, n_black = _scan_svo2(svo_path)
+    return _result_from_scan(ts, sdk_total, n_errors, n_black, svo_mtime_ns)
+
+
+def _episode_svo_paths(episode_dir: Path) -> Dict[str, Path]:
+    """Map ``camera_name -> svo2_path`` for every view present in the episode."""
+    cam_dir = episode_dir / "cameras"
+    return {p.stem: p for p in sorted(cam_dir.glob("*.svo2"))}
+
+
+def _load_episode_cache(episode_dir: Path, force: bool) -> Dict[str, InspectResult]:
+    """Return the per-camera cached results that are still fresh.
+
+    A camera's entry is fresh when its ``svo2_mtime_ns`` matches the current
+    ``.svo2`` mtime.  Cameras with stale/absent entries are omitted (forcing a
+    rescan of just those views).  ``force``, a missing/corrupt cache, or an
+    old flat-schema cache all yield ``{}`` (full rescan).
+    """
+    if force:
+        return {}
+    cache_path = episode_dir / EPISODE_CACHE_NAME
+    if not cache_path.exists():
+        return {}
+    try:
+        cached = json.loads(cache_path.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+    svo_paths = _episode_svo_paths(episode_dir)
+    fresh: Dict[str, InspectResult] = {}
+    for cam, entry in cached.items():
+        if not isinstance(entry, dict):
+            return {}  # legacy flat-schema cache — rescan everything
+        svo = svo_paths.get(cam)
+        if svo is None:
+            continue
+        try:
+            r = InspectResult(**entry)
+        except (TypeError, KeyError):
+            continue
+        if r.svo2_mtime_ns == svo.stat().st_mtime_ns:
+            fresh[cam] = r
+    return fresh
+
+
+def _save_episode_cache(episode_dir: Path, results: Dict[str, InspectResult]) -> None:
+    cache_path = episode_dir / EPISODE_CACHE_NAME
+    cache_path.write_text(
+        json.dumps({cam: asdict(r) for cam, r in results.items()}, indent=2)
+    )
+
+
+def _frame_drops(views: Dict[str, InspectResult]) -> set:
+    """Cameras whose frame count is anomalously low vs the busiest view."""
+    if len(views) < 2:
+        return set()
+    ref = max(r.n_frames for r in views.values())
+    if ref <= 0:
+        return set()
+    return {cam for cam, r in views.items() if r.n_frames < ref * FRAME_DROP_RATIO}
+
+
+def _episode_verdict(
+    views: Dict[str, InspectResult], drops: set, missing: List[str]
+) -> str:
+    """Worst per-view verdict, escalated for dropped or missing views."""
+    verdicts = [r.verdict for r in views.values()]
+    if drops:
+        verdicts.append("bad")
+    if missing:
+        verdicts.append("missing")
+    if not verdicts:
+        return "missing"
+    return max(verdicts, key=lambda v: VERDICT_RANK.get(v, 0))
+
+
+def _print_table(items: List[Tuple[str, Dict]]) -> None:
+    header = (
+        f"{'ep':>5} {'cam':>18} {'n':>5} {'med':>6} {'max':>8} {'p99':>7} "
+        f"{'g>50':>5} {'g>100':>6} {'g>500':>6} {'blk%':>6} {'shrink':>7} "
+        f"{'verdict':>11} {'flag':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    for ep_id, ep in items:
+        views: Dict[str, InspectResult] = ep["views"]
+        drops: set = ep["drops"]
+        missing: List[str] = ep["missing"]
+        first = True
+        for cam in sorted(views):
+            r = views[cam]
+            flag = "BLACK" if r.verdict == "black" else "DROP" if cam in drops else ""
+            print(
+                f"{ep_id if first else '':>5} {cam:>18} {r.n_frames:>5} "
+                f"{r.median_dt_ms:>6.2f} {r.max_dt_ms:>8.1f} {r.p99_dt_ms:>7.1f} "
+                f"{r.gaps_over_50ms:>5} {r.gaps_over_100ms:>6} {r.gaps_over_500ms:>6} "
+                f"{r.black_ratio * 100:>5.1f}% {r.shrink:>6.2f}x {r.verdict:>11} {flag:>8}"
+            )
+            first = False
+        for cam in missing:
+            print(
+                f"{ep_id if first else '':>5} {cam:>18} "
+                f"{'-':>5} {'-':>6} {'-':>8} {'-':>7} "
+                f"{'-':>5} {'-':>6} {'-':>6} {'-':>6} {'-':>7} "
+                f"{'missing':>11} {'MISSING':>8}"
+            )
+            first = False
+
+
+def inspect_task(
+    task_dir: Path, force: bool = False, workers: Optional[int] = None
+) -> Dict:
+    """Inspect every episode in a task, print a per-episode table, and save report.
+
+    Per-camera results are cached at ``<episode>/inspect.json`` (each entry
+    mtime-keyed against its ``.svo2``); only changed/uncached views are
+    rescanned.  Every view that needs a scan — across all episodes — runs in a
+    single shared thread pool (``workers`` threads, default
+    :func:`_default_workers`), so scans overlap across episodes rather than one
+    episode at a time.  The task-level ``inspect_report.json`` aggregate is
+    rebuilt from the per-episode files on every run.
+    """
+    task_dir = Path(task_dir)
+    ep_dirs = sorted(d for d in task_dir.iterdir() if _is_episode_dir(d))
+    if not ep_dirs:
+        print(f"No episodes with cameras/*.svo2 found in {task_dir}")
+        return {}
+
+    print(f"Task: {task_dir.name}  ({len(ep_dirs)} episodes)\n")
+
+    # Reuse fresh per-camera cache, then flatten every view still needing a scan
+    # — across all episodes — into one job list so the whole task fills a single
+    # shared thread pool instead of scanning one episode at a time.
+    ep_by_id = {d.name: d for d in ep_dirs}
+    raw: Dict[str, Dict[str, InspectResult]] = {}
+    jobs: List[Tuple[str, str, Path]] = []
+    for ep_dir in ep_dirs:
+        cached = _load_episode_cache(ep_dir, force=force)
+        raw[ep_dir.name] = dict(cached)
+        for cam, svo in _episode_svo_paths(ep_dir).items():
+            if cam not in cached:
+                jobs.append((ep_dir.name, cam, svo))
+
+    if jobs:
+        n_workers = workers or _default_workers()
+        print(
+            f"Scanning {len(jobs)} view(s) across {len(ep_dirs)} episode(s) "
+            f"with {n_workers} workers..."
+        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as ex:
+            futs = {
+                ex.submit(_analyze_svo, svo): (ep_id, cam) for ep_id, cam, svo in jobs
+            }
+            for fut in concurrent.futures.as_completed(futs):
+                ep_id, cam = futs[fut]
+                try:
+                    raw[ep_id][cam] = fut.result()
+                except Exception as e:
+                    print(f"  {ep_id}/{cam}: scan failed ({e})")
+        for ep_id in {ep_id for ep_id, _, _ in jobs}:
+            if raw[ep_id]:
+                _save_episode_cache(ep_by_id[ep_id], raw[ep_id])
+
+    raw = {ep_id: views for ep_id, views in raw.items() if views}
+    expected_cams = sorted({cam for views in raw.values() for cam in views})
+
+    episodes: Dict[str, Dict] = {}
+    for ep_id, views in raw.items():
+        drops = _frame_drops(views)
+        missing = [cam for cam in expected_cams if cam not in views]
+        episodes[ep_id] = {
+            "views": views,
+            "drops": drops,
+            "missing": missing,
+            "verdict": _episode_verdict(views, drops, missing),
+        }
+
+    items = sorted(episodes.items())
+    _print_table(items)
+
+    counts = {
+        "clean": 0,
+        "borderline": 0,
+        "bad": 0,
+        "broken": 0,
+        "black": 0,
+        "missing": 0,
+    }
+    for ep in episodes.values():
+        counts[ep["verdict"]] = counts.get(ep["verdict"], 0) + 1
+    print(
+        f"\nSummary (per-episode, worst view): clean={counts['clean']}  "
+        f"borderline={counts['borderline']}  bad={counts['bad']}  "
+        f"broken={counts['broken']}  black={counts['black']}  "
+        f"missing={counts['missing']}  (scanned {len(episodes)})"
+    )
+
+    report = {
+        "task": task_dir.name,
+        "total_episodes": len(ep_dirs),
+        "scanned_episodes": len(episodes),
+        "expected_cameras": expected_cams,
+        "verdicts": counts,
+        "thresholds": {
+            "clean_shrink_max": CLEAN_SHRINK,
+            "borderline_shrink_max": BORDERLINE_SHRINK,
+            "bad_shrink_max": BAD_SHRINK,
+            "clean_max_dt_ms": CLEAN_MAX_DT_MS,
+            "borderline_max_dt_ms": BORDERLINE_MAX_DT_MS,
+            "bad_max_dt_ms": BAD_MAX_DT_MS,
+            "min_frames": MIN_FRAMES,
+            "frame_drop_ratio": FRAME_DROP_RATIO,
+            "black_mean_max": BLACK_MEAN_MAX,
+            "black_ratio": BLACK_RATIO,
+        },
+        "episodes": {
+            ep_id: {
+                "verdict": ep["verdict"],
+                "drops": sorted(ep["drops"]),
+                "missing": ep["missing"],
+                "views": {cam: asdict(r) for cam, r in ep["views"].items()},
+            }
+            for ep_id, ep in items
+        },
+    }
+    report_path = task_dir / TASK_REPORT_NAME
+    report_path.write_text(json.dumps(report, indent=2))
+    print(f"Report saved to: {report_path}")
+
+    return report
+
+
+def select_inspect_tasks(data_dir: str = "data/raw") -> List[str]:
+    """Use fzf to select one or more raw recording task directories (Tab to multi-select)."""
+    base = Path(data_dir)
+    if not base.exists():
+        print(f"No recordings found in {base}")
+        sys.exit(1)
+
+    task_dirs = sorted(
+        d
+        for d in base.iterdir()
+        if d.is_dir()
+        and any(_is_episode_dir(sub) for sub in d.iterdir() if sub.is_dir())
+    )
+
+    if not task_dirs:
+        print(f"No tasks with cameras/*.svo2 recordings found in {base}")
+        sys.exit(1)
+
+    labels = {
+        f"{d.name}  ({sum(1 for s in d.iterdir() if _is_episode_dir(s))} recording(s))": d
+        for d in task_dirs
+    }
+
+    from raiden.utils import fzf_select
+
+    selected = fzf_select(list(labels), prompt="Inspect task(s)> ", multi=True)
+    if not selected:
+        return []
+    if isinstance(selected, str):
+        selected = [selected]
+    return [str(labels[s]) for s in selected]
+
+
+def run_inspect(
+    recording_dir: Optional[str] = None,
+    data_dir: str = "data",
+    force: bool = False,
+    workers: Optional[int] = None,
+) -> None:
+    """Entry point for ``rd inspect``.
+
+    With ``recording_dir`` set, inspect exactly that task directory; otherwise
+    open an fzf selector over ``<data_dir>/raw`` (Tab to multi-select tasks).
+    """
+    if recording_dir is not None:
+        inspect_task(Path(recording_dir), force=force, workers=workers)
+        return
+    for task_dir in select_inspect_tasks(str(Path(data_dir) / "raw")):
+        inspect_task(Path(task_dir), force=force, workers=workers)
+        print()

--- a/raiden/shardify.py
+++ b/raiden/shardify.py
@@ -90,6 +90,18 @@ class ShardifyConfig:
     #: Only feed every N-th sample into the stats accumulators to save memory.
     stats_stride: int = 10
 
+    # Recovery-data (HG-DAgger) subsetting
+    #: Which anchor frames to keep, by per-frame ``control_source``:
+    #: ``"all"`` (every frame), ``"interventions"`` (only human-takeover frames,
+    #: ``control_source == 1``), or ``"interventions_context"`` (interventions
+    #: plus the ``keep_context`` policy frames leading into each one — the drift
+    #: window). ``"all"`` is the ABC-preferred recipe (keep diversity, upweight
+    #: corrections via ``sample_weight``).
+    keep: str = "all"
+    #: Number of leading policy frames to retain before each intervention when
+    #: ``keep == "interventions_context"``.
+    keep_context: int = 15
+
 
 # ---------------------------------------------------------------------------
 # Rotation helpers
@@ -745,6 +757,34 @@ def select_processed_task(data_dir: str = "data") -> List[Tuple[Path, List[Path]
 # ---------------------------------------------------------------------------
 
 
+def _keep_anchor(
+    control_source: np.ndarray,
+    t: int,
+    keep: str,
+    keep_context: int,
+    n_frames: int,
+) -> bool:
+    """Decide whether anchor frame ``t`` survives the ``--keep`` filter.
+
+    - ``"all"``: always keep.
+    - ``"interventions"``: keep only human-takeover frames (``control_source==1``).
+    - ``"interventions_context"``: keep interventions plus the ``keep_context``
+      policy frames leading into each one. Implemented as a forward look-ahead —
+      frame ``t`` is kept iff an intervention begins within the next
+      ``keep_context`` frames, which is exactly the drift window before it.
+      ``max(1, keep_context)`` means ``keep_context == 0`` still keeps the single
+      frame immediately before an intervention (not "interventions only").
+    """
+    if keep == "all":
+        return True
+    if control_source[t] == 1:
+        return True
+    if keep == "interventions_context":
+        hi = min(n_frames, t + max(1, keep_context) + 1)
+        return bool((control_source[t:hi] == 1).any())
+    return False  # keep == "interventions" and this is a policy frame
+
+
 def _build_sample(
     args: tuple,
 ) -> Dict[str, Any]:
@@ -770,6 +810,17 @@ def _build_sample(
     control = ctx["control"]
     ep_dir = ctx["ep_dir"]
     s = config.stride
+
+    # ── keep filter (HG-DAgger recovery-data subsetting) ──────────────
+    # Runs first, before any window/image work, so dropped anchors are cheap.
+    # NOTE: on data without control_source (ordinary teleop, or converts made
+    # before this feature) the array is all-zero, so keep != "all" yields ZERO
+    # samples — the filter empties the set rather than no-opping. Use keep=all
+    # (the default) on non-dagger data.
+    if not _keep_anchor(
+        ctx["control_source"], t, config.keep, config.keep_context, n_frames
+    ):
+        return {"filtered": "keep"}
 
     # ── padding filter ────────────────────────────────────────────────
     left_frames_needed = config.past_lowdim_steps * s
@@ -853,6 +904,15 @@ def _build_sample(
         "original_episode_length": n_frames,
         "is_padded": left_pad > 0 or right_pad > 0,
         "control": control,
+        # Recovery-data provenance, so a merged shard set stays splittable for
+        # the ABC 80:10:10 base/intervention mix.
+        "episode_kind": ctx["episode_kind"],
+        "is_intervention": bool(
+            np.asarray(frames[t].get("is_intervention", False)).reshape(-1)[0]
+        ),
+        "sample_weight": float(
+            np.asarray(frames[t].get("sample_weight", 1.0)).reshape(-1)[0]
+        ),
     }
     sample_files[f"{sample_uuid}.metadata.json"] = json.dumps(sample_meta).encode()
 
@@ -933,6 +993,7 @@ def run_shardify(
     filtered_padding = 0
     filtered_still = 0
     filtered_nan = 0
+    filtered_keep = 0
     stats_counter = 0
 
     # ── Phase 1: load all episodes ────────────────────────────────────────
@@ -954,11 +1015,22 @@ def run_shardify(
         anchor_frame = frames[0]
         with open(ep_dir / "metadata.json") as _mf:
             _ep_meta = json.load(_mf)
+        # Per-frame human-takeover flag, read once so the keep filter and the
+        # interventions_context look-ahead are O(1) per anchor. Defaults to all
+        # zeros on ordinary (non-dagger) episodes.
+        control_source = np.array(
+            [
+                int(np.asarray(fr.get("control_source", 0)).reshape(-1)[0])
+                for fr in frames
+            ],
+            dtype=np.int8,
+        )
         ep_contexts.append(
             {
                 "ep_dir": ep_dir,
                 "frames": frames,
                 "n_frames": len(frames),
+                "control_source": control_source,
                 "src_cam_names": [
                     _reverse_map(config.camera_name_map, out_cam)
                     for out_cam in output_cam_names
@@ -967,6 +1039,7 @@ def run_shardify(
                 "language_prompt": str(anchor_frame.get("language_prompt", "")),
                 "episode_id": ep_dir.name,
                 "control": _ep_meta.get("control", "leader"),
+                "episode_kind": _ep_meta.get("episode_kind", "teleop"),
             }
         )
         total_frames += len(frames)
@@ -1003,6 +1076,8 @@ def run_shardify(
                 filtered_still += 1
             elif result["filtered"] == "nan":
                 filtered_nan += 1
+            elif result["filtered"] == "keep":
+                filtered_keep += 1
             else:
                 writer.add(result["sample_files"])
                 total_samples += 1
@@ -1010,7 +1085,10 @@ def run_shardify(
                 ep_sample_counts[episode_id] = ep_sample_counts.get(episode_id, 0) + 1
                 stats_counter += 1
                 pbar.set_postfix(
-                    filtered=filtered_padding + filtered_still + filtered_nan,
+                    filtered=filtered_padding
+                    + filtered_still
+                    + filtered_nan
+                    + filtered_keep,
                     shard=writer._shard_idx,
                 )
 
@@ -1078,6 +1156,8 @@ def run_shardify(
             "padding_samples_filtered": filtered_padding,
             "still_samples_filtered": filtered_still,
             "nan_samples_filtered": filtered_nan,
+            "keep_samples_filtered": filtered_keep,
+            "keep_mode": config.keep,
             "elapsed_seconds": round(elapsed, 1),
         },
     }
@@ -1086,10 +1166,11 @@ def run_shardify(
     with open(shard_dir / "processing_metadata.json", "w") as f:
         json.dump(proc_meta, f, indent=2)
 
+    keep_msg = f" keep[{config.keep}]={filtered_keep}" if config.keep != "all" else ""
     print(
         f"\nDone: {total_samples} samples → {writer._shard_idx} shards  "
-        f"filtered: {filtered_padding + filtered_still + filtered_nan} "
-        f"(pad={filtered_padding} still={filtered_still} nan={filtered_nan})  "
+        f"filtered: {filtered_padding + filtered_still + filtered_nan + filtered_keep} "
+        f"(pad={filtered_padding} still={filtered_still} nan={filtered_nan}{keep_msg})  "
         f"elapsed: {elapsed:.0f}s"
     )
     print(f"Output: {shard_dir}")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,118 @@
+"""Tests for ``raiden.converter`` recovery-tag resampling.
+
+``control_source`` is a discrete 0/1 human-takeover flag recorded on the robot
+clock and replayed onto the camera-frame grid. Interpolating it would smear it
+into a meaningless fraction, so it is resampled by NEAREST timestamp — these
+tests pin that behaviour down.
+
+Run with::
+
+    uv run pytest tests/test_converter.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from raiden.converter import _resample_flag_nearest
+
+MS = 1_000_000  # nanoseconds per millisecond
+
+
+def test_identity_when_grids_match():
+    robot_ts = np.arange(6, dtype=np.int64) * 10 * MS
+    flag = np.array([0, 0, 1, 1, 0, 0], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, robot_ts)
+    assert np.array_equal(out, flag)
+
+
+def test_output_is_always_a_clean_flag_never_interpolated():
+    """The whole point: sampling across a 0->1 edge must never yield a fraction.
+
+    ``np.interp`` on the same inputs produces intermediate values; nearest does
+    not.
+    """
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    ref_ts = np.linspace(0, 100 * MS, 11).astype(np.int64)
+
+    out = _resample_flag_nearest(flag, robot_ts, ref_ts)
+    assert set(np.unique(out)).issubset({0, 1})
+
+    smeared = np.interp(ref_ts, robot_ts, flag)
+    assert not set(np.unique(smeared)).issubset({0, 1})  # documents the contrast
+
+
+def test_picks_the_nearer_robot_sample():
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    # 40 ms is nearer the first sample, 60 ms nearer the second.
+    out = _resample_flag_nearest(
+        flag, robot_ts, np.array([40 * MS, 60 * MS], dtype=np.int64)
+    )
+    assert out.tolist() == [0, 1]
+
+
+def test_exact_tie_picks_the_earlier_sample():
+    """Ties resolve left (``<=``) so the result is deterministic."""
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, np.array([50 * MS], dtype=np.int64))
+    assert out.tolist() == [0]
+
+
+def test_camera_frame_before_first_robot_sample_clamps_to_first():
+    robot_ts = np.array([100 * MS, 200 * MS], dtype=np.int64)
+    flag = np.array([1, 0], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, np.array([0], dtype=np.int64))
+    assert out.tolist() == [1]
+
+
+def test_camera_frame_after_last_robot_sample_clamps_to_last():
+    robot_ts = np.array([100 * MS, 200 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    out = _resample_flag_nearest(
+        flag, robot_ts, np.array([10_000 * MS], dtype=np.int64)
+    )
+    assert out.tolist() == [1]
+
+
+def test_downsampling_preserves_an_intervention_block():
+    """Robot logs at 100 Hz, cameras at 30 Hz. A takeover spanning robot frames
+    40-59 (400-600 ms) must still be marked on the camera grid."""
+    robot_ts = (np.arange(100) * 10 * MS).astype(np.int64)
+    flag = np.zeros(100, dtype=np.int8)
+    flag[40:60] = 1
+    ref_ts = (np.arange(30) * int(1e9 / 30)).astype(np.int64)
+
+    out = _resample_flag_nearest(flag, robot_ts, ref_ts)
+
+    assert set(np.unique(out)).issubset({0, 1})
+    marked = ref_ts[out == 1]
+    assert marked.min() >= 390 * MS and marked.max() <= 610 * MS
+    assert out.sum() > 0
+
+
+def test_all_policy_and_all_human_are_preserved():
+    robot_ts = (np.arange(10) * 10 * MS).astype(np.int64)
+    ref_ts = (np.arange(5) * 20 * MS).astype(np.int64)
+    zeros = _resample_flag_nearest(np.zeros(10, dtype=np.int8), robot_ts, ref_ts)
+    ones = _resample_flag_nearest(np.ones(10, dtype=np.int8), robot_ts, ref_ts)
+    assert zeros.tolist() == [0] * 5
+    assert ones.tolist() == [1] * 5
+
+
+def test_returns_int8_matching_the_reference_grid_length():
+    robot_ts = (np.arange(10) * 10 * MS).astype(np.int64)
+    ref_ts = (np.arange(7) * 13 * MS).astype(np.int64)
+    out = _resample_flag_nearest(np.ones(10), robot_ts, ref_ts)
+    assert out.dtype == np.int8
+    assert out.shape == (7,)
+
+
+def test_column_shaped_flag_is_flattened():
+    """``robot_data.npz`` may store the flag as (N, 1); it is reshaped to (N,)."""
+    robot_ts = (np.arange(4) * 10 * MS).astype(np.int64)
+    flag = np.array([[0], [1], [1], [0]], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, robot_ts)
+    assert out.tolist() == [0, 1, 1, 0]

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,0 +1,209 @@
+"""Tests for ``raiden.inspector`` verdict classification.
+
+Hardware-free: exercises the pure classification maths, so no ZED SDK and no
+SVO2 files are needed (``pyzed`` is imported lazily inside ``_scan_svo2``).
+
+Run with::
+
+    uv run pytest tests/test_inspector.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from raiden.inspector import (
+    BLACK_RATIO,
+    CLEAN_MAX_DT_MS,
+    CLEAN_SHRINK,
+    MIN_FRAMES,
+    VERDICT_RANK,
+    _classify,
+    _is_episode_dir,
+    _result_from_scan,
+)
+
+FRAME_NS = int(1e9 / 30)  # nominal 30 Hz capture period
+
+
+def _ts(n_frames: int, gaps_ms: dict[int, float] | None = None) -> np.ndarray:
+    """Timestamps for ``n_frames`` at a perfect 30 Hz.
+
+    ``gaps_ms`` adds extra delay (in ms) after the given frame index, simulating
+    a capture stutter.
+    """
+    dt = np.full(n_frames - 1, FRAME_NS, dtype=np.int64)
+    for idx, extra_ms in (gaps_ms or {}).items():
+        dt[idx] += int(extra_ms * 1e6)
+    return np.concatenate([[0], np.cumsum(dt)]).astype(np.int64)
+
+
+# ---------------------------------------------------------------------------
+# _classify — the shrink / max-dt / frame-count verdict ladder
+# ---------------------------------------------------------------------------
+
+
+def test_classify_nominal_recording_is_clean():
+    assert _classify(shrink=1.0, max_dt_ms=33.4, n_frames=1000) == "clean"
+
+
+def test_classify_thresholds_are_exclusive():
+    """Thresholds compare with a strict ``>``, so a value sitting exactly on the
+    boundary stays in the better bucket."""
+    assert _classify(CLEAN_SHRINK, 33.4, 1000) == "clean"
+    assert _classify(1.0, CLEAN_MAX_DT_MS, 1000) == "clean"
+
+
+@pytest.mark.parametrize(
+    ("shrink", "expected"),
+    [(1.0, "clean"), (1.06, "borderline"), (1.11, "bad"), (1.21, "broken")],
+)
+def test_classify_shrink_ladder(shrink, expected):
+    assert _classify(shrink, 33.4, 1000) == expected
+
+
+@pytest.mark.parametrize(
+    ("max_dt_ms", "expected"),
+    [(33.4, "clean"), (201.0, "borderline"), (1001.0, "bad"), (2001.0, "broken")],
+)
+def test_classify_max_dt_ladder(max_dt_ms, expected):
+    assert _classify(1.0, max_dt_ms, 1000) == expected
+
+
+def test_classify_too_few_frames_is_broken():
+    """A near-empty recording is broken however good its timing looks."""
+    assert _classify(1.0, 33.4, MIN_FRAMES - 1) == "broken"
+    assert _classify(1.0, 33.4, MIN_FRAMES) == "clean"
+
+
+def test_classify_worst_axis_wins():
+    """Timing and frame-drop are orthogonal; the worse of the two decides."""
+    assert _classify(shrink=1.0, max_dt_ms=1500.0, n_frames=1000) == "bad"
+    assert _classify(shrink=1.15, max_dt_ms=33.4, n_frames=1000) == "bad"
+
+
+def test_verdict_rank_orders_worst_last():
+    ranked = sorted(VERDICT_RANK, key=lambda v: VERDICT_RANK[v])
+    assert ranked == ["clean", "borderline", "bad", "broken", "black", "missing"]
+
+
+# ---------------------------------------------------------------------------
+# _result_from_scan — raw scan -> classified InspectResult
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_frames", [0, 1])
+def test_result_degenerate_scan_is_broken(n_frames):
+    """Fewer than two timestamps means no interval to measure — broken, and the
+    metrics are zeroed rather than left undefined."""
+    res = _result_from_scan(
+        _ts(2)[:n_frames], sdk_total=10, n_errors=0, n_black=0, svo_mtime_ns=7
+    )
+    assert res.verdict == "broken"
+    assert res.n_frames == n_frames
+    assert res.shrink == 0.0
+    assert res.max_dt_ms == 0.0
+    assert res.svo2_mtime_ns == 7
+
+
+def test_result_nominal_scan_is_clean():
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0
+    )
+    assert res.verdict == "clean"
+    assert res.n_frames == 1000
+    assert res.shrink == pytest.approx(1.0, abs=1e-3)
+    assert res.max_dt_ms == pytest.approx(1000 / 30, abs=1e-3)
+    assert res.gaps_over_50ms == 0
+
+
+def test_result_stutter_degrades_the_verdict_and_counts_gaps():
+    """One long stall shows up in max_dt, the gap counters, and the verdict."""
+    res = _result_from_scan(
+        _ts(1000, {500: 600.0}), sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0
+    )
+    assert res.verdict == "borderline"
+    assert res.max_dt_ms == pytest.approx(1000 / 30 + 600.0, abs=1e-3)
+    assert res.gaps_over_500ms == 1
+    assert res.gaps_over_50ms == 1
+
+
+def test_result_dropped_frames_show_up_as_shrink():
+    """Half the frames lost over the same wall-clock span doubles shrink, so the
+    surviving frames would replay at 2x speed."""
+    ts = _ts(1000)[::2]  # keep every other frame: same span, half the frames
+    res = _result_from_scan(ts, sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0)
+    assert res.shrink == pytest.approx(2.0, abs=1e-2)
+    assert res.verdict == "broken"
+
+
+def test_result_black_left_eye_overrides_timing():
+    """A dead left eye corrupts the training RGB outright, so it beats an
+    otherwise-clean timing verdict."""
+    n_black = int(1000 * BLACK_RATIO) + 1
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1000, n_errors=0, n_black=n_black, svo_mtime_ns=0
+    )
+    assert res.verdict == "black"
+    assert res.black_ratio == pytest.approx(n_black / 1000)
+
+
+def test_result_black_ratio_threshold_is_exclusive():
+    """Exactly at BLACK_RATIO is not black — the check is a strict ``>``."""
+    res = _result_from_scan(
+        _ts(1000),
+        sdk_total=1000,
+        n_errors=0,
+        n_black=int(1000 * BLACK_RATIO),
+        svo_mtime_ns=0,
+    )
+    assert res.verdict == "clean"
+
+
+def test_result_preserves_timing_metrics_under_a_black_verdict():
+    """The timing numbers stay available for diagnosis even when black wins."""
+    res = _result_from_scan(
+        _ts(1000, {500: 600.0}), sdk_total=1000, n_errors=0, n_black=500, svo_mtime_ns=0
+    )
+    assert res.verdict == "black"
+    assert res.gaps_over_500ms == 1
+
+
+def test_result_reports_grab_errors_verbatim():
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1010, n_errors=10, n_black=0, svo_mtime_ns=0
+    )
+    assert res.n_grab_errors == 10
+    assert res.sdk_total_frames == 1010
+
+
+# ---------------------------------------------------------------------------
+# _is_episode_dir — what counts as an episode on disk
+# ---------------------------------------------------------------------------
+
+
+def test_is_episode_dir_requires_cameras_with_svo2(tmp_path):
+    ep = tmp_path / "0000"
+    (ep / "cameras").mkdir(parents=True)
+    (ep / "cameras" / "scene_camera.svo2").touch()
+    assert _is_episode_dir(ep) is True
+
+
+def test_is_episode_dir_rejects_empty_cameras_dir(tmp_path):
+    ep = tmp_path / "0000"
+    (ep / "cameras").mkdir(parents=True)
+    assert _is_episode_dir(ep) is False
+
+
+def test_is_episode_dir_rejects_dir_without_cameras(tmp_path):
+    ep = tmp_path / "0000"
+    ep.mkdir()
+    (ep / "robot_data.npz").touch()
+    assert _is_episode_dir(ep) is False
+
+
+def test_is_episode_dir_rejects_a_file(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.touch()
+    assert _is_episode_dir(f) is False

--- a/tests/test_shardify.py
+++ b/tests/test_shardify.py
@@ -1,0 +1,104 @@
+"""Tests for ``raiden.shardify`` ``--keep`` subsetting.
+
+``_keep_anchor`` decides which anchor frames survive the keep filter, so a whole
+recorded rollout can be subset to the human corrections (and the drift window
+leading into them) at shard time rather than at record time.
+
+Run with::
+
+    uv run pytest tests/test_shardify.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from raiden.shardify import _keep_anchor
+
+
+def _keep_mask(control_source, keep, keep_context=15):
+    """Apply the filter across a whole episode, returning the kept indices."""
+    cs = np.asarray(control_source, dtype=np.int8)
+    n = len(cs)
+    return [t for t in range(n) if _keep_anchor(cs, t, keep, keep_context, n)]
+
+
+# ---------------------------------------------------------------------------
+# keep == "all" — the default, unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_all_keeps_every_frame():
+    cs = [0, 0, 1, 1, 0]
+    assert _keep_mask(cs, "all") == [0, 1, 2, 3, 4]
+
+
+def test_all_keeps_a_pure_teleop_episode():
+    """Ordinary demos have control_source all-zero and must be untouched."""
+    assert _keep_mask([0] * 6, "all") == list(range(6))
+
+
+# ---------------------------------------------------------------------------
+# keep == "interventions" — corrections only
+# ---------------------------------------------------------------------------
+
+
+def test_interventions_keeps_only_human_frames():
+    cs = [0, 0, 1, 1, 0, 1]
+    assert _keep_mask(cs, "interventions") == [2, 3, 5]
+
+
+def test_interventions_on_a_teleop_episode_keeps_nothing():
+    """The documented footgun: control_source is 0 for every ordinary teleop
+    frame, so this mode empties a non-dagger dataset."""
+    assert _keep_mask([0] * 10, "interventions") == []
+
+
+def test_interventions_ignores_keep_context():
+    """Lead-in frames belong to interventions_context only."""
+    cs = [0, 0, 0, 1]
+    assert _keep_mask(cs, "interventions", keep_context=2) == [3]
+
+
+# ---------------------------------------------------------------------------
+# keep == "interventions_context" — corrections plus the drift window
+# ---------------------------------------------------------------------------
+
+
+def test_context_keeps_the_lead_in_frames():
+    """With keep_context=2, the two policy frames before the takeover survive
+    and the earlier drift does not."""
+    cs = [0, 0, 0, 1, 0]
+    assert _keep_mask(cs, "interventions_context", keep_context=2) == [1, 2, 3]
+
+
+def test_context_does_not_keep_frames_after_an_intervention():
+    """The window is a forward look-ahead: it captures the approach to a
+    takeover, not the recovery after it."""
+    cs = [0, 1, 0, 0, 0]
+    kept = _keep_mask(cs, "interventions_context", keep_context=2)
+    assert kept == [0, 1]
+
+
+def test_context_zero_still_keeps_the_frame_immediately_before():
+    """max(1, keep_context) means 0 is not silently 'interventions only'."""
+    cs = [0, 0, 1]
+    assert _keep_mask(cs, "interventions_context", keep_context=0) == [1, 2]
+
+
+def test_context_window_is_clamped_at_the_episode_end():
+    """A window running past the last frame must not raise or wrap."""
+    cs = [0, 0, 0]
+    assert _keep_mask(cs, "interventions_context", keep_context=100) == []
+
+
+def test_context_spans_two_separate_takeovers():
+    cs = [0, 0, 1, 0, 0, 0, 1, 0]
+    kept = _keep_mask(cs, "interventions_context", keep_context=1)
+    assert kept == [1, 2, 5, 6]
+
+
+def test_context_keeps_a_fully_human_episode_intact():
+    assert _keep_mask([1] * 5, "interventions_context", keep_context=3) == list(
+        range(5)
+    )


### PR DESCRIPTION
## Summary

Two additions to the offline data pipeline, both born from silent data-quality failures we hit while collecting large teleop + HG-DAgger datasets on YAM rigs:

1. **`rd inspect`** — a pre-flight quality checker for raw recordings. It scans every episode's SVO2 streams in parallel and flags frame-stutter, dropped frames, and black/failed camera streams **before** hours are spent converting (or worse, training) on bad data. Episodes get a verdict (`clean / borderline / bad / broken / black / missing`) with per-camera reasons and a summary table; results are cached in the episode dir (`--force` re-scans).
2. **Per-frame provenance tags in convert + shardify** — `rd convert` now writes `control_source` (0 = policy, 1 = human), `is_intervention`, and `sample_weight` into every lowdim frame, and `rd shardify` can subset on them (`--keep interventions | interventions_context | all`). This is the data-side groundwork for HG-DAgger interactive-correction collection (the collection loop itself is a follow-up PR): record whole rollouts, tag who was in control, and let the trainer mix/upweight (ABC-style 80:10:10) without re-touching raw data.

## Details

- `raiden/inspector.py` (new): SVO2 scan comparing frame count against wall-clock span (shrink factor), max inter-frame dt, and black-frame detection; camera-name agnostic; thresholds documented at the top of the module.
- `raiden/converter.py`:
  - resamples the discrete `control_source` flag onto the camera-frame grid by **nearest timestamp** (never interpolated — it's a 0/1 flag), and only on the ns-timestamp alignment path;
  - `--w-intervention N` optionally upweights human-takeover frames (default `1.0` — ABC uses dataset mixing, not per-frame weights, so tags alone suffice);
  - `--append` converts new raw episodes into an existing converted dataset (numbering continues from the max existing episode, split metadata rebuilt over all episodes).
- `raiden/shardify.py`: `--keep` subsetting with `--keep-context N` frames of lead-in before each intervention; filtered counts surfaced in `processing_metadata.json`; per-sample metadata carries `sample_weight` / `is_intervention` / `episode_kind` so merged shard sets stay splittable.
- CLI wiring for `rd inspect` + the new convert/shardify flags; docs: user-guide page (`docs/guide/inspection.md`) and API reference, wired into the nav.

## Backward compatibility

Ordinary teleop recordings convert exactly as before, except each lowdim frame gains the three new keys with neutral defaults (`control_source=0`, `is_intervention=False`, `sample_weight=1.0`) and episode metadata gains `episode_kind="teleop"`. No existing key changes. `--keep all` is the shardify default, so existing pipelines are unaffected.

## Testing

**47 hardware-free unit tests** in a new `tests/` directory — no ZED SDK, SVO2 files, or robot required (`pyzed` is imported lazily inside `_scan_svo2`, so the modules import on a bare machine):

| File | Covers |
|---|---|
| `tests/test_inspector.py` | `_classify` / `_result_from_scan` — the verdict ladder, exclusive threshold boundaries, worst-axis-wins, degenerate scans, the black-left-eye override; `_is_episode_dir` on a temp tree |
| `tests/test_converter.py` | `_resample_flag_nearest` — nearest-not-interpolated, ties, out-of-range clamping, 100 Hz → 30 Hz downsampling, dtype/shape |
| `tests/test_shardify.py` | `_keep_anchor` — all / interventions / interventions_context, look-ahead window, `keep_context=0`, end clamping, the empty-dataset footgun |

Two tests are worth calling out as executable documentation of *why* the code is written the way it is: one asserts `np.interp` on the same inputs smears `control_source` into fractions while `_resample_flag_nearest` does not, and one pins that `--keep interventions` yields **zero** samples on a pure-teleop dataset.

This is the repo's first `tests/` directory and there's no test job in CI, so they run locally with `uv run pytest tests/ -v`. Happy to add a CI job and a pytest dev-dependency if you want them gating.

`ruff format --check` + `ruff check` clean; `mkdocs build --strict` clean with the docs-CI dependency set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
