### PR TITLE
Add rd infer: local inference loop with HG-DAgger interactive correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the **[Installation guide](https://tri-ml.github.io/raiden/guide/installatio
 | `rd calibrate` | Calibrate cameras (hand-eye + scene extrinsics) |
 | `rd teleop` | Teleoperate arms without recording |
 | `rd record` | Record teleoperation demonstrations |
+| `rd inspect` | Check raw recordings for frame-stutter and blackouts |
 | `rd replay` | Replay recorded follower arm motion |
 | `rd console` | Browse and correct demonstration metadata in a terminal UI |
 | `rd convert` | Convert successful recordings to a structured dataset |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See the **[Installation guide](https://tri-ml.github.io/raiden/guide/installatio
 | `rd shardify` | Export converted episodes to WebDataset shards |
 | `rd visualize` | Visualize a converted recording with Rerun |
 | `rd serve` | Start the policy server for live inference |
+| `rd infer` | Local inference loop + HG-DAgger interactive correction |
 | `rd make_ffs_onnx` | Export Fast Foundation Stereo model to ONNX / TensorRT engines |
 | `rd make_tri_stereo_engine` | Compile TRI Stereo TensorRT engine from ONNX model |
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -5,6 +5,7 @@
       members:
         - TeleopCommand
         - RecordCommand
+        - InspectCommand
         - ConvertCommand
         - VisualizeCommand
         - CalibrateCommand

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -7,6 +7,7 @@
         - RecordCommand
         - InspectCommand
         - ConvertCommand
+        - InferCommand
         - VisualizeCommand
         - CalibrateCommand
         - RecordCalibrationPosesCommand

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -1,0 +1,3 @@
+# Inference
+
+::: raiden.inference

--- a/docs/api/inspector.md
+++ b/docs/api/inspector.md
@@ -1,0 +1,3 @@
+# Inspector
+
+::: raiden.inspector

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -11,8 +11,9 @@
 7. **[Convert to dataset](conversion.md)** - extract frames, synchronize multi-camera streams, and interpolate joint poses into a structured dataset.
 8. **[Shardify](shardify.md)** - export converted episodes to WebDataset sharded `.tar` files for policy training.
 9. **[Evaluation](serve.md)** - run the live policy inference server (chiral protocol).
-10. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
-11. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
+10. **[Recovery data collection](recovery.md)** - collect HG-DAgger interactive corrections to fix a drifting policy.
+11. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
+12. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
 
 ## Commands
 
@@ -26,6 +27,7 @@
 | `rd convert` | Convert raw recordings to a structured dataset |
 | `rd shardify` | Export converted episodes to WebDataset shards |
 | `rd serve` | Start the chiral policy server for live inference |
+| `rd infer` | Local inference loop + HG-DAgger interactive correction |
 | `rd replay` | Replay recorded follower arm motion |
 | `rd visualize` | Visualize a converted recording with Rerun |
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -7,11 +7,12 @@
 3. **[Install software](installation.md)** - install Raiden and hardware SDKs.
 4. **[Calibrate cameras](calibration.md)** - hand-eye calibration for wrist cameras and static extrinsics for the scene camera.
 5. **[Record demonstrations](recording.md)** - capture teleoperation episodes with synchronized cameras and robot joint data.
-6. **[Convert to dataset](conversion.md)** - extract frames, synchronize multi-camera streams, and interpolate joint poses into a structured dataset.
-7. **[Shardify](shardify.md)** - export converted episodes to WebDataset sharded `.tar` files for policy training.
-8. **[Evaluation](serve.md)** - run the live policy inference server (chiral protocol).
-9. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
-10. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
+6. **[Inspect data quality](inspection.md)** - flag frame-stutter and black frames in raw recordings before converting.
+7. **[Convert to dataset](conversion.md)** - extract frames, synchronize multi-camera streams, and interpolate joint poses into a structured dataset.
+8. **[Shardify](shardify.md)** - export converted episodes to WebDataset sharded `.tar` files for policy training.
+9. **[Evaluation](serve.md)** - run the live policy inference server (chiral protocol).
+10. **[Replay](replay.md)** - replay recorded follower arm motion on the physical hardware to verify a recording.
+11. **[Visualize](visualization.md)** - inspect converted recordings interactively in Rerun.
 
 ## Commands
 
@@ -21,6 +22,7 @@
 | `rd calibrate` | Calibrate cameras (hand-eye + scene extrinsics) |
 | `rd teleop` | Teleoperate arms without recording |
 | `rd record` | Record teleoperation demonstrations |
+| `rd inspect` | Check raw recordings for frame-stutter and blackouts |
 | `rd convert` | Convert raw recordings to a structured dataset |
 | `rd shardify` | Export converted episodes to WebDataset shards |
 | `rd serve` | Start the chiral policy server for live inference |

--- a/docs/guide/inspection.md
+++ b/docs/guide/inspection.md
@@ -1,0 +1,113 @@
+# Data quality inspection
+
+The `rd inspect` command scans raw SVO2 recordings for **frame-stutter** and
+**left-eye blackouts** before you convert them, so silent capture problems are
+caught while they can still be re-recorded — not discovered as corrupt training
+data weeks later.
+
+## Usage
+
+```bash
+rd inspect
+```
+
+Running the command opens an interactive fzf selector over the task directories
+in `./data/raw/`. Use Tab to toggle individual tasks and Enter to confirm; each
+selected task is scanned and reported.
+
+Inspect a single task directory directly (skips the selector):
+
+```bash
+rd inspect --recording-dir data/raw/pick_cube
+```
+
+Point at a different data root, or force a full rescan ignoring the cache:
+
+```bash
+rd inspect --data-dir /mnt/storage/robot_data
+rd inspect --recording-dir data/raw/pick_cube --force
+```
+
+## Why inspect before converting
+
+Two capture faults are invisible in the recording verdict but corrupt the data
+downstream:
+
+- **Frame stutter.** [`rd replay`](replay.md) and the training pipeline treat the
+  surviving frames as a uniformly-spaced 30 Hz stream. If the camera dropped
+  frames during capture, the real time between two surviving frames collapses to
+  a single 1/30 s step — producing bursts of unphysically fast motion and
+  mislabelled actions. `rd inspect` measures the ratio of real elapsed duration
+  to the ideal 30 Hz duration (`shrink`) and the largest inter-frame gap.
+- **Black left eye.** [`rd convert`](conversion.md) writes the stereo **LEFT**
+  view to training RGB. A dropped left sensor produces uniformly black frames
+  that the timestamp scan cannot see, so the images are checked directly.
+
+The check runs on **every** `cameras/*.svo2` view (wrist cameras can drop frames
+independently of the scene camera) and is camera-name agnostic — any directory
+holding a `cameras/` folder with at least one `.svo2` file is treated as an
+episode.
+
+## Verdicts
+
+Each episode gets a single verdict — the **worst** of its per-camera views,
+escalated if a view is missing or has anomalously few frames.
+
+| Verdict | Meaning |
+|---|---|
+| `clean` | Steady 30 Hz, no meaningful gaps. Use as-is. |
+| `borderline` | Minor stutter (shrink > 1.05 or a gap > 200 ms). Still usable. |
+| `bad` | Noticeable stutter (shrink > 1.10 or a gap > 1 s). Inspect before training on it. |
+| `broken` | Severe stutter (shrink > 1.20, a gap > 2 s, or fewer than 10 frames). Re-record. |
+| `black` | More than 10 % of left-eye frames are black — the RGB is corrupt regardless of timing. Re-record. |
+| `missing` | A view present in other episodes is absent here, or a `.svo2` failed to open. |
+
+A view is additionally flagged `DROP` when its frame count is below 95 % of the
+busiest view in the same episode (cameras grab in lock-step, so a large
+discrepancy means one view lost frames).
+
+## What it checks
+
+For each view the scan reports:
+
+| Metric | Description |
+|---|---|
+| `n` | Frames actually decoded from the SVO2. |
+| `median` / `max` / `p99` (ms) | Inter-frame time gaps. `max` drives the timing verdict. |
+| `g>50` / `g>100` / `g>500` | Count of gaps exceeding 50 / 100 / 500 ms. |
+| `blk%` | Fraction of frames whose left eye is black. |
+| `shrink` | Real duration ÷ ideal 30 Hz duration. 1.00 = perfect; higher = dropped frames. |
+
+## Output
+
+Results are cached and aggregated so re-runs are cheap:
+
+```
+data/raw/<task>/
+    inspect_report.json         # task-level aggregate (rebuilt every run)
+    0000/
+        inspect.json            # per-camera cache, keyed by each .svo2 mtime
+        cameras/*.svo2
+    0001/
+        inspect.json
+        ...
+```
+
+Each camera's result is cached against its `.svo2` modification time, so a re-run
+only re-scans views whose file changed (or are new). Pass `--force` to ignore the
+cache entirely.
+
+`inspect_report.json` records the per-episode verdicts, the drop/missing views,
+the full per-view metrics, and the thresholds used — a machine-readable manifest
+you can gate conversion or export on.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--recording-dir` | *interactive* | Inspect one task directory directly instead of the fzf selector. |
+| `--data-dir` | `data` | Root data directory; the selector lists tasks under `<data_dir>/raw/`. |
+| `--force` | `False` | Ignore the per-episode `inspect.json` cache and rescan every view. |
+| `--workers` | `min(cpu, 8)` | Concurrent SVO2 scans. |
+
+Run `rd inspect --help` for the full list.

--- a/docs/guide/recovery.md
+++ b/docs/guide/recovery.md
@@ -1,0 +1,239 @@
+# Recovery data collection (HG-DAgger)
+
+High-precision tasks often fail because clean success demonstrations never show a
+near-miss, so a policy that drifts off-course has no learned way back.
+**HG-DAgger** collects the missing data: you deploy the policy, take over with the
+leader arms at the exact moment it starts to fail, correct it, and hand back — all
+recorded as one episode with a per-frame flag marking who was in control. Feed
+those corrections back into training (the ABC recipe) and the policy learns to
+recover.
+
+This is an interactive-correction loop layered on top of the local inference
+command `rd infer`. It follows the ABC paper (§5.3): record the **whole rollout**
+and upweight the human corrections, rather than training on interventions alone.
+
+!!! note "HG-DAgger needs a policy; it runs on the robot"
+    `rd infer` loads a model **in-process** on the robot host through a
+    `ModelBridge` (see [Writing a bridge](#writing-a-modelbridge)). This is a
+    separate path from [`rd serve`](serve.md), which streams observations to a
+    remote policy over the chiral protocol. HG-DAgger lives in the local loop
+    because that is the only place the followers are commanded and the leaders can
+    be read for takeover.
+
+## Prerequisites
+
+- A trained checkpoint and a `ModelBridge` that loads it.
+- Leader **and** follower arms connected with CAN up, plus the ZED cameras — the
+  same rig as [recording](recording.md). (Ordinary `rd serve` leaves the leaders
+  off; `--intervene` powers them so you can take over.)
+- The model and its framework importable on the robot host.
+
+!!! warning "Keep your hands off the leaders during start-up"
+    In intervene mode the leaders are powered during homing and — with shadow
+    tracking (the default) — keep moving under power during autonomy to mirror the
+    followers. Do not rest your hands on them; press a trigger only when you want
+    to take over.
+
+## The operator loop
+
+```
+  ┌─ policy runs autonomously (you watch) ──┐
+  │                                         │
+  │   you see it start to fail              │
+  ▼                                         │
+  press a leader trigger ──▶ you take over INSTANTLY (the leader already mirrors
+                             the follower; it goes compliant — move it to correct)
+                                            │
+  press the trigger again ──▶ hand back     │
+                                            │
+  the policy resumes from the EXACT pose    │
+  you left, re-observes, re-predicts ───────┘   (repeat as many times as needed)
+
+  Ctrl+C ──▶ arms return home, THEN the whole rollout is saved as ONE episode
+```
+
+## Running it
+
+```bash
+rd infer \
+    --bridge my_model.bridge:MyBridge \
+    --ckpt-path /path/to/checkpoint \
+    --intervene \
+    --dagger-task box_fold_dagger_r1 \
+    --dagger-instruction "fold the box flap"
+```
+
+- `--intervene` turns on the takeover state machine and **auto-enables recording**.
+- `--dagger-task` is the directory the rollout is saved under (also the round
+  label — see [Organizing rounds](#organizing-rounds-for-the-801010-mix)).
+- `--dagger-instruction` is the language prompt stored with the episode.
+- `--leader-track` (default **on**) keeps the leaders mirroring the followers
+  during autonomy, so takeover is instant and seam-free. Pass `--no-leader-track`
+  to keep them still until you take over — they then sync to the follower over
+  ~1.5 s when you first press a trigger (hands off during that sync).
+
+Without `--intervene`, `rd infer` runs the policy autonomously; add `--record`
+alone to capture a pure-policy rollout (`control_source` all 0).
+
+### Taking over and handing back
+
+- **Press a leader trigger** (either arm) to toggle `policy → teleop`. Takeover is
+  instant — the leader already tracks the follower, so it goes compliant exactly
+  where the arm is and you move it from there (joint-space delta, no jump at the
+  seam). The other arm holds its position.
+- **Press again** to hand back. The policy resumes from the exact pose you left,
+  takes a fresh observation, re-predicts, and continues — no blending, no reset to
+  home.
+- Toggle as many times as you like in one rollout; every segment is flagged.
+- The terminal shows the live mode (`[HUMAN]` while you drive, `[policy]`
+  otherwise) and the loop rate.
+
+!!! note "The human is the safety authority during takeover"
+    `rd infer` enforces a per-step joint-delta limit (`--max-joint-delta`) while
+    the **policy** drives, aborting on a runaway command. That check is skipped
+    while **you** are driving — a deliberate correction is not a fault.
+
+### Stopping
+
+`Ctrl+C` — exactly like a normal deploy: the arms **return home first** (while CAN
+is healthy), then the rollout is saved. The arms do not go limp. The heavy save
+runs only after the arms are home and de-energised.
+
+```
+data/raw/box_fold_dagger_r1/0000/
+    cameras/{scene_camera,left_wrist_camera,right_wrist_camera}.svo2
+    robot_data.npz     # standard keys + control_source (0 = policy, 1 = you)
+    metadata.json      # episode_kind=dagger, intervention_ratio
+```
+
+!!! note "One episode, both pools"
+    Your interventions and the policy's own frames live in the **same** episode,
+    distinguished by `control_source` — there is no separate intervention file.
+    The camera is shared with inference (one ZED handle records SVO2 while still
+    feeding the policy), not a second process.
+
+## Convert — tag and optionally upweight
+
+```bash
+rd convert                        # tags only (ABC mixing recipe)
+rd convert --w-intervention 8     # also upweight human-takeover frames ×8
+```
+
+`rd convert` writes a per-frame `control_source`, `is_intervention`, and
+`sample_weight` into every lowdim file, and carries `episode_kind` and
+`intervention_ratio` forward into the converted episode metadata. `control_source`
+is resampled onto the camera grid by **nearest timestamp** (never interpolated —
+it is a discrete flag). Plain teleop demos convert exactly as before, with all
+weights `1.0`.
+
+`--w-intervention` is optional. ABC uses dataset **mixing**, not per-frame
+weights — if you build the 80:10:10 mix at train time you can leave it at `1.0`
+and rely on the tags.
+
+## Shardify — optionally subset
+
+```bash
+rd shardify                                          # all frames (default)
+rd shardify --keep interventions                     # only your corrections
+rd shardify --keep interventions_context --keep-context 15   # corrections + 15 frames of lead-in
+```
+
+You recorded the whole rollout once; choose the training subset here. Each shard
+sample's `metadata.json` carries `sample_weight`, `is_intervention`, and
+`episode_kind`, so a merged shard set stays splittable.
+
+!!! warning "`--keep interventions*` empties a non-dagger dataset"
+    The keep filter selects on `control_source`, which is 0 for every ordinary
+    teleop frame. Running `--keep interventions` on data without human takeovers
+    yields **zero** samples. Use `--keep all` (the default) on non-dagger data.
+
+## Organizing rounds for the 80:10:10 mix
+
+A "round" is just a directory. Give each round its own `--dagger-task`:
+
+```
+data/raw/box_fold/            # base teleop demos           ── 80 % pool (prior rounds)
+data/raw/box_fold_dagger_r1/  # round-1 HG-DAgger rollouts  ── after r1, joins the prior pool
+data/raw/box_fold_dagger_r2/  # round-2 HG-DAgger rollouts  ── 20 % current (split 10/10 by control_source)
+```
+
+Convert and shardify each round into its own directory, then mix the shard
+directories **80 : 10 : 10** at train time:
+
+| Pool | Where |
+|---|---|
+| 80 % | base + earlier-round shard dirs |
+| 10 % | current round, samples with `is_intervention == True` |
+| 10 % | current round, samples with `is_intervention == False` |
+
+This implicitly overweights interventions (a minority of frames given an equal
+10 % share) while keeping whole rollouts — the ABC recipe.
+
+## Trainer-side consumption
+
+Each shard sample's `metadata.json` carries the provenance. Either weight the loss:
+
+```python
+meta = json.loads(sample["metadata.json"])
+loss = per_sample_loss * meta["sample_weight"]     # 1.0 for normal frames
+```
+
+…or route samples on `episode_kind` / `is_intervention` into the three pools and
+sample them at 0.8 / 0.1 / 0.1. Raiden emits the tags; this routing is the only
+change needed in the training repo.
+
+## Writing a `ModelBridge`
+
+`rd infer` is model-agnostic. Implement `ModelBridge` from `raiden.inference` and
+point `--bridge` at it:
+
+```python
+from raiden.inference import ModelBridge
+import numpy as np
+
+class MyBridge(ModelBridge):
+    def load(self, ckpt_path: str, **kwargs) -> None:
+        self.model = load_my_model(ckpt_path)
+
+    def reset(self) -> None:
+        """Discard any cached action chunk — called on every handback so the
+        policy re-infers on the current observation."""
+        ...
+
+    def predict(self, obs) -> np.ndarray:
+        """Return a (14,) float32 joint command:
+        [left_arm(6), left_grip(1), right_arm(6), right_grip(1)]."""
+        ...
+```
+
+!!! warning "Action ordering is left-then-right"
+    The `(14,)` joint action is `[left_arm(6), left_grip(1), right_arm(6),
+    right_grip(1)]` — the same left-then-right convention Raiden uses internally
+    for `--action-type ee_pose` and in [`rd serve`](serve.md). Getting the order
+    wrong silently mirrors the robot.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--bridge` | *required* | `module.path:ClassName` implementing `ModelBridge`. |
+| `--ckpt-path` | *required* | Checkpoint passed to `bridge.load()`. |
+| `--intervene` | `False` | Enable the HG-DAgger takeover loop (implies `--record`). |
+| `--record` | `False` | Record a pure-policy rollout (no leaders). |
+| `--dagger-task` | *interactive* | Directory / round name the rollout is saved under. |
+| `--dagger-instruction` | — | Language prompt stored with the episode. |
+| `--session` | `False` | Looped collection — record many rollouts in one run (BOTTOM button ends an episode, `s`/`d` saves or discards) instead of one Ctrl+C-terminated rollout. |
+| `--leader-track` / `--no-leader-track` | on | Shadow the leaders onto the followers during autonomy for instant takeover. |
+| `--action-hz` | `30.0` | Control-loop rate; match the training data rate. |
+| `--action-type` | `joint` | `joint` (14-D) or `ee_pose` (20-D EE pose solved with IK). |
+| `--reset-pose` | — | Move the followers to the first frame of a `robot_data.npz` before the rollout. |
+| `--max-joint-delta` | `0.8` | Per-step joint-delta safety limit (policy mode only). |
+
+Run `rd infer --help` for the full list.
+
+## Related
+
+- [Evaluation](serve.md) — remote policy serving with `rd serve`.
+- [Recording](recording.md) — base teleoperation demonstrations.
+- [Conversion](conversion.md) and [Shardify](shardify.md) — the pipeline the tags flow through.
+- [Data quality inspection](inspection.md) — check the rollout SVO2 before converting.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,8 +62,9 @@ nav:
     - "8. Conversion": guide/conversion.md
     - "9. Shardify": guide/shardify.md
     - "10. Evaluation": guide/serve.md
-    - "11. Replay": guide/replay.md
-    - "12. Visualization": guide/visualization.md
+    - "11. Recovery Data Collection": guide/recovery.md
+    - "12. Replay": guide/replay.md
+    - "13. Visualization": guide/visualization.md
     - Safety: guide/safety.md
     - FAQ: guide/faq.md
   - API Reference:
@@ -74,6 +75,7 @@ nav:
     - Recorder: api/recorder.md
     - Converter: api/converter.md
     - Inspector: api/inspector.md
+    - Inference: api/inference.md
     - Visualizer: api/visualizer.md
     - Calibration: api/calibration.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,11 +58,12 @@ nav:
     - "4. Calibration": guide/calibration.md
     - "5. Console": guide/console.md
     - "6. Recording": guide/recording.md
-    - "7. Conversion": guide/conversion.md
-    - "8. Shardify": guide/shardify.md
-    - "9. Evaluation": guide/serve.md
-    - "10. Replay": guide/replay.md
-    - "11. Visualization": guide/visualization.md
+    - "7. Data Quality Inspection": guide/inspection.md
+    - "8. Conversion": guide/conversion.md
+    - "9. Shardify": guide/shardify.md
+    - "10. Evaluation": guide/serve.md
+    - "11. Replay": guide/replay.md
+    - "12. Visualization": guide/visualization.md
     - Safety: guide/safety.md
     - FAQ: guide/faq.md
   - API Reference:
@@ -72,6 +73,7 @@ nav:
     - Camera Config: api/camera_config.md
     - Recorder: api/recorder.md
     - Converter: api/converter.md
+    - Inspector: api/inspector.md
     - Visualizer: api/visualizer.md
     - Calibration: api/calibration.md
 

--- a/raiden/cli.py
+++ b/raiden/cli.py
@@ -414,6 +414,77 @@ class ServeCommand:
     """Path to calibration_results.json (default: ~/.config/raiden/calibration_results.json)"""
 
 
+@dataclass
+class InferCommand:
+    """Run a local model-agnostic inference loop (ModelBridge), optionally with HG-DAgger"""
+
+    bridge: str
+    """ModelBridge to load, as 'module.path:ClassName' (required)"""
+
+    ckpt_path: str
+    """Path to the model checkpoint passed to bridge.load() (required)"""
+
+    action_hz: float = 30.0
+    """Control-loop frequency in Hz (should match the training data frame rate)"""
+
+    action_type: Literal["joint", "ee_pose"] = "joint"
+    """Action space: 'joint' (14-D joint positions, left then right) or 'ee_pose' (20-D EE poses, IK solved on-the-fly)"""
+
+    intervene: bool = False
+    """Bring up the passive leaders + the policy<->teleop HG-DAgger state machine (implies --record)"""
+
+    record: bool = False
+    """Record the rollout with a per-frame control_source flag (implied by --intervene)"""
+
+    dagger_task: Optional[str] = None
+    """Task name for recorded rollouts (default: interactive fzf selector)"""
+
+    dagger_instruction: Optional[str] = None
+    """Language instruction for the recorded task (default: looked up from the DB)"""
+
+    session: bool = False
+    """Looped collection: record many rollouts in one run (leader BOTTOM button ends an episode, keyboard s/d saves or discards) instead of a single Ctrl+C-terminated rollout"""
+
+    leader_track: bool = True
+    """Shadow tracking: in policy mode the leaders continuously mirror the followers for instant, seam-free takeover (default: True; --no-leader-track uses a ~1.5s sync at takeover)"""
+
+    reset_pose: Optional[str] = None
+    """Move the followers to the first frame of this robot_data.npz before the rollout (default: none)"""
+
+    data_dir: str = "data"
+    """Root data directory (default: ./data); recorded rollouts go to <data_dir>/raw/<task>/"""
+
+    max_joint_delta: float = 0.8
+    """Maximum allowed joint delta per policy step in radians before the loop e-stops (policy mode only)"""
+
+    stereo_method: Literal["zed", "ffs", "tri_stereo"] = "zed"
+    """Depth backend: 'zed' (SDK NEURAL_LIGHT), 'ffs' (Fast Foundation Stereo), or 'tri_stereo' (TRI Stereo)"""
+
+    ffs_scale: float = 1.0
+    """Input resize scale for FFS inference (e.g. 0.5 halves resolution for speed)"""
+
+    ffs_iters: int = 8
+    """FFS update iterations (range 4–32)"""
+
+    tri_stereo_variant: Literal["c32", "c64"] = "c64"
+    """TRI Stereo model variant: 'c64' (higher quality) or 'c32' (faster)"""
+
+    no_depth: bool = False
+    """Disable depth sensing on ZED cameras (faster, no NEURAL_LIGHT inference)"""
+
+    resize_images: Optional[str] = "384x384"
+    """Resize images to HxW before passing to the model (default: '384x384'). Pass empty string to disable."""
+
+    visualize: bool = False
+    """Stream camera images to a Rerun web viewer at 30 FPS"""
+
+    camera_config_file: str = ""
+    """Path to camera.json (default: ~/.config/raiden/camera.json)"""
+
+    calibration_file: str = ""
+    """Path to calibration_results.json (default: ~/.config/raiden/calibration_results.json)"""
+
+
 def _load_spacemouse_config(path: str = SPACEMOUSE_CONFIG) -> dict:
     try:
         with open(path) as f:
@@ -450,6 +521,9 @@ def _print_help() -> None:
     print("  reset_can                   Reset CAN interfaces (bring down then up)")
     print(
         "  serve                       Start the chiral policy server for live inference"
+    )
+    print(
+        "  infer                       Run a local inference loop (ModelBridge); --intervene for HG-DAgger"
     )
     print(
         "  make_ffs_onnx               Export Fast Foundation Stereo model to ONNX / TensorRT engines"
@@ -787,6 +861,51 @@ def main():
                 resize_images_size=resize,
                 visualize=command.visualize,
             )
+
+        elif subcommand == "infer":
+            sys.argv.pop(1)
+            command = tyro.cli(
+                InferCommand,
+                description="Run a local model-agnostic inference loop, optionally with HG-DAgger interactive correction",
+            )
+            from raiden.inference import RaidenInferenceLoop, load_bridge
+
+            resize: tuple | None = None
+            if command.resize_images:
+                h, w = command.resize_images.split("x")
+                resize = (int(h), int(w))
+
+            bridge = load_bridge(command.bridge)
+            loop = RaidenInferenceLoop(
+                bridge,
+                ckpt_path=command.ckpt_path,
+                action_hz=command.action_hz,
+                intervene=command.intervene,
+                record=command.record,
+                dagger_task=command.dagger_task,
+                dagger_instruction=command.dagger_instruction,
+                reset_pose=command.reset_pose,
+                leader_track=command.leader_track,
+                data_dir=command.data_dir,
+                camera_config_file=command.camera_config_file or CAMERA_CONFIG,
+                calibration_file=command.calibration_file or CALIBRATION_FILE,
+                stereo_method=command.stereo_method,
+                ffs_scale=command.ffs_scale,
+                ffs_iters=command.ffs_iters,
+                tri_stereo_variant=command.tri_stereo_variant,
+                max_joint_delta=command.max_joint_delta,
+                action_type=command.action_type,
+                no_depth=command.no_depth,
+                resize_images_size=resize,
+                visualize=command.visualize,
+            )
+            try:
+                if command.session:
+                    loop.run_session()
+                else:
+                    loop.run()
+            except KeyboardInterrupt:
+                print("\nShutting down...")
 
         elif subcommand == "make_ffs_onnx":
             sys.argv.pop(1)

--- a/raiden/cli.py
+++ b/raiden/cli.py
@@ -235,6 +235,29 @@ class ConvertCommand:
     reconvert: bool = False
     """Re-convert all successful demonstrations even if already marked as converted (default: False)"""
 
+    append: bool = False
+    """Number new episodes after the highest existing one and rebuild split_all.json (ignores the DB; adds newly recorded episodes without renumbering existing ones)"""
+
+    w_intervention: float = 1.0
+    """Per-sample loss weight written onto HG-DAgger human-takeover frames (control_source==1); 1.0 = no upweighting (default)"""
+
+
+@dataclass
+class InspectCommand:
+    """Inspect raw SVO2 recordings for frame-stutter and left-eye blackouts before converting"""
+
+    recording_dir: Optional[str] = None
+    """Path to a single raw task directory to inspect (default: interactive fzf selector over <data_dir>/raw)"""
+
+    data_dir: str = "data"
+    """Root data directory (default: ./data); the selector lists tasks under <data_dir>/raw/"""
+
+    force: bool = False
+    """Ignore the per-episode inspect.json cache and rescan every view (default: False)"""
+
+    workers: Optional[int] = None
+    """Concurrent SVO2 scans (default: min(cpu_count, 8))"""
+
 
 @dataclass
 class ReplayCommand:
@@ -340,6 +363,12 @@ class ShardifyCommand:
     use_depth: bool = False
     """Include depth images (.depth.png) in shards (default: False)"""
 
+    keep: Literal["all", "interventions", "interventions_context"] = "all"
+    """HG-DAgger subsetting by per-frame control_source: 'all' (every frame), 'interventions' (only human-takeover frames), or 'interventions_context' (interventions + the keep_context frames before each). Note: 'interventions*' yield ZERO samples on non-dagger data (default: all)"""
+
+    keep_context: int = 15
+    """Policy frames to retain before each intervention when keep=interventions_context (default: 15)"""
+
 
 @dataclass
 class ServeCommand:
@@ -403,6 +432,9 @@ def _print_help() -> None:
     print("  record                      Record teleoperation demonstrations")
     print(
         "  convert                     Convert SVO2/bag recordings to UnifiedDataset format"
+    )
+    print(
+        "  inspect                     Check raw recordings for frame-stutter and blackouts"
     )
     print("  replay                      Replay recorded follower arm motion")
     print("  visualize                   Visualize a converted recording with Rerun")
@@ -581,7 +613,24 @@ def main():
                     reconvert=command.reconvert,
                     processed_base=str(_Path(command.data_dir) / "processed"),
                     tri_stereo_variant=command.tri_stereo_variant,
+                    append=command.append,
+                    w_intervention=command.w_intervention,
                 )
+
+        elif subcommand == "inspect":
+            sys.argv.pop(1)
+            command = tyro.cli(
+                InspectCommand,
+                description="Inspect raw SVO2 recordings for frame-stutter and left-eye blackouts",
+            )
+            from raiden.inspector import run_inspect
+
+            run_inspect(
+                recording_dir=command.recording_dir,
+                data_dir=command.data_dir,
+                force=command.force,
+                workers=command.workers,
+            )
 
         elif subcommand == "visualize":
             sys.argv.pop(1)
@@ -641,6 +690,8 @@ def main():
                     num_workers=command.num_workers,
                     stats_stride=command.stats_stride,
                     use_depth=command.use_depth,
+                    keep=command.keep,
+                    keep_context=command.keep_context,
                 )
                 run_shardify(
                     episode_dirs,

--- a/raiden/converter.py
+++ b/raiden/converter.py
@@ -526,6 +526,24 @@ def _apply_camera_trim(
 # ---------------------------------------------------------------------------
 
 
+def _resample_flag_nearest(
+    flag_raw: np.ndarray, robot_ts: np.ndarray, ref_ts: np.ndarray
+) -> np.ndarray:
+    """Resample a discrete per-robot-frame flag onto the camera-frame grid by
+    NEAREST timestamp.
+
+    Used for ``control_source`` — a 0/1 human-takeover flag that must never be
+    linearly interpolated (``np.interp`` would smear it into a meaningless
+    fraction). For each camera timestamp we pick the robot sample whose timestamp
+    is closest, so the flag stays a clean 0/1.
+    """
+    flag_raw = np.asarray(flag_raw).reshape(-1)
+    ridx = np.clip(np.searchsorted(robot_ts, ref_ts), 1, len(robot_ts) - 1)
+    pick_left = np.abs(ref_ts - robot_ts[ridx - 1]) <= np.abs(ref_ts - robot_ts[ridx])
+    ridx = np.clip(np.where(pick_left, ridx - 1, ridx), 0, len(flag_raw) - 1)
+    return flag_raw[ridx].astype(np.int8)
+
+
 def _build_lowdim(
     seq_dir: Path,
     cameras: List[str],
@@ -538,6 +556,7 @@ def _build_lowdim(
     right_base_to_left_base: Optional[np.ndarray],
     cam_timestamps: Dict[str, Optional[np.ndarray]],
     wrist_camera_joint_keys: Optional[Dict[str, str]] = None,
+    w_intervention: float = 1.0,
 ) -> None:
     """Write seq_dir/lowdim.npz with all cameras' intrinsics/extrinsics plus joints, action, language.
 
@@ -556,6 +575,11 @@ def _build_lowdim(
                              [l_pos(3), l_rot9(9), l_gripper(1), r_pos(3), r_rot9(9), r_gripper(1)].
     ``language_task``        str  task name.
     ``language_prompt``      str  task instruction.
+    ``control_source``       int8  0 = policy drove this frame, 1 = human takeover
+                             (HG-DAgger). All-zero for ordinary teleop.
+    ``is_intervention``      bool  ``control_source == 1``.
+    ``sample_weight``        float32  per-sample loss weight; ``w_intervention`` on
+                             human-takeover frames, else 1.0.
     """
     _WALL_CLOCK_MIN_NS = 1_577_836_800_000_000_000
 
@@ -575,6 +599,11 @@ def _build_lowdim(
                 break
 
     robot_ts: Optional[np.ndarray] = None
+    # True only when ref_ts and robot_ts share the same camera-SDK nanosecond
+    # clock (the normal path). The recovery tags below are resampled by nearest
+    # timestamp, so they are only meaningful when the two grids are comparable;
+    # on the legacy linspace fallback we leave the tags at their defaults.
+    ts_aligned = False
     if robot_data is not None and n_frames > 0:
         robot_ts_raw = robot_data.get("timestamps")
         if (
@@ -583,6 +612,7 @@ def _build_lowdim(
             and robot_ts_raw.dtype == np.int64
         ):
             robot_ts = robot_ts_raw.astype(np.float64)
+            ts_aligned = True
         else:
             # Legacy: uniform linspace over the recording duration.
             duration = rec_meta.get("duration_s", 1.0)
@@ -812,6 +842,27 @@ def _build_lowdim(
     language_task = np.array(rec_meta.get("task_name", ""), dtype=object)
     language_prompt = np.array(rec_meta.get("task_instruction", ""), dtype=object)
 
+    # ── recovery-data provenance tags (HG-DAgger) ─────────────────────────
+    # Resample the per-robot-frame control_source flag onto the camera grid by
+    # NEAREST NEIGHBOUR — never np.interp, which would smear the discrete 0/1
+    # takeover flag into a meaningless fraction. Ordinary teleop recordings have
+    # no control_source key, so every frame defaults to policy/weight-1.0 and the
+    # tags are a harmless, uniform addition to the schema.
+    control_source = np.zeros(n_frames, dtype=np.int8)
+    is_intervention = np.zeros(n_frames, dtype=bool)
+    sample_weight = np.ones(n_frames, dtype=np.float32)
+    cs_raw = robot_data.get("control_source") if robot_data is not None else None
+    if (
+        cs_raw is not None
+        and ts_aligned
+        and robot_ts is not None
+        and ref_ts is not None
+        and len(robot_ts) >= 2
+    ):
+        control_source = _resample_flag_nearest(cs_raw, robot_ts, ref_ts)
+        is_intervention = control_source == 1
+        sample_weight[is_intervention] *= float(w_intervention)
+
     # ── write per-frame files into lowdim/ ────────────────────────────────
     lowdim_dir = seq_dir / "lowdim"
     lowdim_dir.mkdir(parents=True, exist_ok=True)
@@ -830,6 +881,9 @@ def _build_lowdim(
             frame_data["action_joints"] = action_joints[i]
         frame_data["language_task"] = language_task
         frame_data["language_prompt"] = language_prompt
+        frame_data["control_source"] = control_source[i]
+        frame_data["is_intervention"] = bool(is_intervention[i])
+        frame_data["sample_weight"] = sample_weight[i]
         if right_base_to_left_base is not None:
             frame_data["T_left_from_right"] = right_base_to_left_base
         with open(lowdim_dir / f"{i:010d}.pkl", "wb") as f:
@@ -883,6 +937,11 @@ def _build_sequence_metadata(
         "extrinsics": {"transform": "cam2world", "metric": True},
         "action": {"format": "joint_cmd", "dims": 14},
         "control": rec_meta.get("control", "leader"),
+        # Recovery-data provenance carried raw → converted so shardify can build
+        # the ABC 80:10:10 base/intervention mix. Defaults keep ordinary demos as
+        # plain teleop episodes.
+        "episode_kind": rec_meta.get("episode_kind", "teleop"),
+        "intervention_ratio": rec_meta.get("intervention_ratio"),
     }
 
     with open(seq_dir / "metadata.json", "w") as f:
@@ -957,6 +1016,7 @@ def convert_recording(
     ffs_iters: int = 8,
     tri_stereo_variant: str = "c64",
     reconvert: bool = False,
+    w_intervention: float = 1.0,
 ) -> Dict[str, int]:
     """Convert a recording directory to UnifiedDataset format.
 
@@ -1197,6 +1257,7 @@ def convert_recording(
         right_base_to_left_base=T_left_base_from_right_base,
         cam_timestamps=cam_timestamps,
         wrist_camera_joint_keys=wrist_camera_joint_keys,
+        w_intervention=w_intervention,
     )
     print(f"  ✓ lowdim/ ({n_min} frames)")
 
@@ -1239,6 +1300,8 @@ def convert_task(
     reconvert: bool = False,
     processed_base: Optional[str] = None,
     tri_stereo_variant: str = "c64",
+    append: bool = False,
+    w_intervention: float = 1.0,
 ) -> None:
     """Convert all recordings in a task directory into a single UnifiedDataset.
 
@@ -1288,45 +1351,67 @@ def convert_task(
     except Exception:
         _db = None
 
-    # Filter recordings: skip failures/pending, and (unless reconvert) already
-    # converted ones.  Recordings with no DB entry are treated as unknown and
-    # included so directories recorded before the DB was set up are not dropped.
-    success_dirs = []
-    skipped = 0
-    for rec_dir in recording_dirs:
-        status = "unknown"
-        already_converted = False
-        if _db is not None:
-            try:
-                demo = _db.get_demonstration_by_raw_path(str(rec_dir))
-                if demo is not None:
-                    status = demo.get("status", "pending")
-                    already_converted = bool(demo.get("converted", False))
-            except Exception:
-                pass
-        if status not in ("success", "unknown"):
-            print(f"  Skipping {rec_dir.name} (status={status})")
-            skipped += 1
-        elif already_converted and not reconvert:
-            print(
-                f"  Skipping {rec_dir.name} (already converted, use --reconvert to force)"
-            )
-            skipped += 1
-        else:
-            success_dirs.append(rec_dir)
+    # ── select recordings + choose the starting episode number ────────────
+    # Default: renumber episodes 0000.. from scratch, DB-filtered.
+    # --append: number new episodes after the highest existing one and ignore
+    # the DB (so freshly added recordings extend the dataset instead of clobbering
+    # or renumbering the episodes already on disk).
+    if append:
+        success_dirs = [
+            d for d in recording_dirs if any((d / "cameras").glob("*.svo2"))
+        ]
+        existing_nums = [
+            int(p.name) for p in out_base.iterdir() if p.is_dir() and p.name.isdigit()
+        ]
+        append_start = (max(existing_nums) + 1) if existing_nums else 0
+        if not success_dirs:
+            print("No recordings with SVO2 files to append.")
+            return
+        print(
+            f"Appending {len(success_dirs)} recording(s) starting at "
+            f"episode {append_start:04d}\n"
+        )
+    else:
+        # Filter recordings: skip failures/pending, and (unless reconvert) already
+        # converted ones.  Recordings with no DB entry are treated as unknown and
+        # included so directories recorded before the DB was set up are not dropped.
+        append_start = 0
+        success_dirs = []
+        skipped = 0
+        for rec_dir in recording_dirs:
+            status = "unknown"
+            already_converted = False
+            if _db is not None:
+                try:
+                    demo = _db.get_demonstration_by_raw_path(str(rec_dir))
+                    if demo is not None:
+                        status = demo.get("status", "pending")
+                        already_converted = bool(demo.get("converted", False))
+                except Exception:
+                    pass
+            if status not in ("success", "unknown"):
+                print(f"  Skipping {rec_dir.name} (status={status})")
+                skipped += 1
+            elif already_converted and not reconvert:
+                print(
+                    f"  Skipping {rec_dir.name} (already converted, use --reconvert to force)"
+                )
+                skipped += 1
+            else:
+                success_dirs.append(rec_dir)
 
-    if skipped:
-        print(f"\nSkipped {skipped} non-success recording(s).")
-    if not success_dirs:
-        print("No successful recordings to convert.")
-        return
+        if skipped:
+            print(f"\nSkipped {skipped} non-success recording(s).")
+        if not success_dirs:
+            print("No successful recordings to convert.")
+            return
 
-    print(f"Converting {len(success_dirs)} successful recording(s)\n")
+        print(f"Converting {len(success_dirs)} successful recording(s)\n")
 
-    for i, rec_dir in enumerate(success_dirs):
-        episode_name = f"{i:04d}"
+    for offset, rec_dir in enumerate(success_dirs):
+        episode_name = f"{append_start + offset:04d}"
         ep_dir = out_base / episode_name
-        print(f"[{i + 1}/{len(success_dirs)}] {rec_dir.name} → {episode_name}/")
+        print(f"[{offset + 1}/{len(success_dirs)}] {rec_dir.name} → {episode_name}/")
         counts = convert_recording(
             str(rec_dir),
             episode_dir=str(ep_dir),
@@ -1335,6 +1420,7 @@ def convert_task(
             ffs_iters=ffs_iters,
             tri_stereo_variant=tri_stereo_variant,
             reconvert=reconvert,
+            w_intervention=w_intervention,
         )
 
         if counts:
@@ -1363,6 +1449,20 @@ def convert_task(
                 pass
 
     # ── combined split_all.json ────────────────────────────────────────────
+    # When appending, the split must span the whole dataset on disk (existing +
+    # newly appended episodes), not just the ones converted this run.
+    if append:
+        episode_frame_counts = {}
+        for p in sorted(out_base.iterdir()):
+            if not (p.is_dir() and p.name.isdigit()):
+                continue
+            meta_file = p / "metadata.json"
+            n_frames = 0
+            if meta_file.exists():
+                with open(meta_file) as f:
+                    n_frames = json.load(f).get("num_frames", 0)
+            episode_frame_counts[p.name] = n_frames
+
     total_frames = sum(episode_frame_counts.values())
     n_eps = len(episode_frame_counts)
     split = {

--- a/raiden/inference.py
+++ b/raiden/inference.py
@@ -89,9 +89,9 @@ class ModelBridge(ABC):
     joint order (TRI convention)::
 
         [0:6]   left arm joint angles (rad)
-        [6]     left gripper (0=open, 1=closed)
+        [6]     left gripper (0=closed, 1=open)
         [7:13]  right arm joint angles (rad)
-        [13]    right gripper (0=open, 1=closed)
+        [13]    right gripper (0=closed, 1=open)
 
     This is the same layout the TRI server's ``_ee_pose_to_joint_cmd`` produces
     for ``action_type="ee_pose"``, so both action types command the same arms.

--- a/raiden/inference.py
+++ b/raiden/inference.py
@@ -1,0 +1,1243 @@
+"""Model-agnostic inference loop for the YAM bimanual robot (+ HG-DAgger).
+
+Provides:
+
+- ``ModelBridge`` — abstract interface for model-specific logic.
+- ``RaidenInferenceLoop`` — camera/motor infrastructure + control loop, plus the
+  ``--intervene`` HG-DAgger interactive-correction state machine.
+
+The split: **raiden** owns hardware (cameras, motors, 14-D joint commands); the
+**model repo** owns everything model-specific (action space, preprocessing,
+inference, action chunking) behind the :class:`ModelBridge` seam.
+
+Usage from a model repo::
+
+    # your_model/deployment/yam_bridge.py
+    from raiden.inference import ModelBridge, RaidenInferenceLoop
+
+    class MyBridge(ModelBridge):
+        def load(self, ckpt_path, **kwargs): ...
+        def predict(self, obs):             ...  # returns (14,)
+
+Or via CLI::
+
+    rd infer --bridge your_model.deployment.yam_bridge:MyBridge \\
+             --ckpt-path /path/to/checkpoint.pt
+
+HG-DAgger (interactive correction)::
+
+    rd infer --bridge ... --ckpt-path ... --intervene
+
+    # Leader TOP button  : toggle policy <-> teleop (take over / hand back)
+    # Leader BOTTOM button: end the episode (looped collection only)
+
+Thread layout (inherited from RaidenPolicyServer)::
+
+    camera-<name>       : grabs frames from ZED at ~30 Hz (per camera)
+    proprio-<name>      : reads joint state at ~100 Hz
+    dagger-input        : owns ALL leader CAN I/O (reads + shadow commands)
+    main thread         : inference loop (gated by bridge.predict() speed)
+
+Arm-ordering convention (TRI)
+-----------------------------
+The 14-D joint action is **LEFT-then-RIGHT**::
+
+    action[0:7]   = left arm  (6 joints + gripper)   → follower_l
+    action[7:14]  = right arm (6 joints + gripper)   → follower_r
+
+This matches the TRI server's ``_smooth_command``, ``_check_joint_delta``, and
+``_ee_pose_to_joint_cmd`` (which returns ``concatenate([left, right])``), so
+joint mode and ee_pose mode command the same arms.  (The YAM source packed
+RIGHT-then-LEFT; this port adopts TRI's order end to end.)
+"""
+
+import importlib
+import shutil
+import threading
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from chiral.types import Observation
+
+from raiden.robot.controller import joint_delta_takeover, smooth_move_joints
+from raiden.server import RaidenPolicyServer
+
+DOF = 7  # joints per arm (6 revolute + 1 gripper)
+
+
+# ---------------------------------------------------------------------------
+# Abstract bridge interface
+# ---------------------------------------------------------------------------
+
+
+class ModelBridge(ABC):
+    """Abstract interface between a policy model and the YAM robot.
+
+    Implement this in your model's repo to handle all model-specific logic:
+
+    - Model loading (checkpoint format, framework imports)
+    - Observation preprocessing (image resize, pointmaps, state assembly,
+      normalization — whatever your model's action space requires)
+    - Inference (forward pass)
+    - Action postprocessing (denormalization, chunking, format conversion)
+
+    ``predict()`` receives a raw :class:`chiral.types.Observation` and must
+    return a ``(14,)`` float32 array of motor commands in **LEFT-then-RIGHT**
+    joint order (TRI convention)::
+
+        [0:6]   left arm joint angles (rad)
+        [6]     left gripper (0=open, 1=closed)
+        [7:13]  right arm joint angles (rad)
+        [13]    right gripper (0=open, 1=closed)
+
+    This is the same layout the TRI server's ``_ee_pose_to_joint_cmd`` produces
+    for ``action_type="ee_pose"``, so both action types command the same arms.
+
+    Action chunking, if used, must be managed internally — ``predict()`` is
+    called once per control step and returns exactly one action.
+    """
+
+    @abstractmethod
+    def load(self, ckpt_path: str, **kwargs) -> None:
+        """Load model from checkpoint.
+
+        Args:
+            ckpt_path: Path to the model checkpoint.
+            **kwargs (Any): Model-specific arguments (e.g. ``chunk_size``,
+                ``device``).
+        """
+
+    @abstractmethod
+    def predict(self, obs: Observation) -> np.ndarray:
+        """Given a raw observation, return an action for the loop's action type.
+
+        The return shape depends on the ``--action-type`` the loop runs with:
+
+        - ``joint`` (default): ``(14,)`` float32 joint commands
+          ``[left_joints(6), left_grip(1), right_joints(6), right_grip(1)]``,
+          sent to the motors as-is.
+        - ``ee_pose``: ``(20,)`` float32 end-effector pose
+          ``[l_xyz(3), r_xyz(3), l_rot6d(6), r_rot6d(6), l_grip(1), r_grip(1)]``,
+          which the loop converts to a ``(14,)`` joint command via the server's
+          ``_ee_pose_to_joint_cmd`` (IK). Left-before-right throughout.
+
+        Args:
+            obs: Raw observation with ``obs.cameras`` (list of ``CameraInfo``),
+                ``obs.proprios`` (dict of ``(N,)`` float32 arrays), and
+                ``obs.timestamp`` (float).
+        """
+
+    def reset(self) -> None:
+        """Called when the robot is homed / control is handed back.
+
+        Override to reset internal state (e.g. clear the action-chunk buffer so
+        the next ``predict()`` re-infers on the current observation).  This is
+        the whole HG-DAgger handback seam — a fresh inference on the exact pose
+        the human left, giving a zero-jump resume.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Inference loop
+# ---------------------------------------------------------------------------
+
+
+class RaidenInferenceLoop(RaidenPolicyServer):
+    """Model-agnostic inference loop for the YAM robot (+ HG-DAgger).
+
+    Reuses :class:`~raiden.server.RaidenPolicyServer`'s camera capture, depth
+    computation, proprioception reading, and motor control, delegating all
+    model-specific logic to a :class:`ModelBridge`.
+
+    Args:
+        bridge: a ``ModelBridge`` implementation from the model repo.
+        ckpt_path: passed to ``bridge.load()``.
+        action_hz: control-loop frequency in Hz (default 30, should match the
+            training data frame rate).
+        bridge_kwargs: extra keyword arguments forwarded to ``bridge.load()``.
+        intervene: bring up the passive leader arms + the policy<->teleop button
+            state machine (implies ``record``).
+        record: record the rollout with a per-frame ``control_source`` flag.
+        dagger_task: task / round name the rollout is saved under (skips the
+            interactive task prompt).
+        dagger_instruction: language instruction stored with the episode.
+        reset_pose: optional path to a ``robot_data.npz`` whose first frame the
+            followers are moved to before the rollout.
+        leader_track: shadow tracking — in policy mode the leaders continuously
+            mirror the followers so takeover is instant + seam-free (default on).
+        data_dir: root data dir; recordings go to ``<data_dir>/raw/<task>/``.
+        **kwargs (Any): forwarded to ``RaidenPolicyServer`` (camera_config_file,
+            calibration_file, stereo_method, action_type, max_joint_delta, ...).
+    """
+
+    def __init__(
+        self,
+        bridge: ModelBridge,
+        ckpt_path: str,
+        action_hz: float = 30.0,
+        bridge_kwargs: Optional[dict] = None,
+        intervene: bool = False,
+        record: bool = False,
+        dagger_task: Optional[str] = None,
+        dagger_instruction: Optional[str] = None,
+        reset_pose: Optional[str] = None,
+        leader_track: bool = True,
+        data_dir: str = "data",
+        **kwargs,
+    ):
+        self._bridge = bridge
+        self._action_hz = action_hz
+        self._data_dir = data_dir
+
+        # HG-DAgger config.  ``intervene`` brings up the (passive) leader arms
+        # and a button-driven policy<->teleop state machine; it implies recording.
+        self._intervene = intervene
+        self._record = record or intervene
+        self._dagger_task = dagger_task
+        self._dagger_instruction = dagger_instruction
+        self._reset_pose = reset_pose
+        # Shadow tracking: during policy mode, continuously drive the leaders onto
+        # the followers so takeover is instant + seam-free (vs the ~1.5 s blocking
+        # sync used when this is off).  See _dagger_input_loop.
+        self._leader_track = leader_track
+
+        # State-machine state (only used when intervening).
+        self._mode = "policy"  # "policy" | "teleop"
+        self._mode_lock = threading.Lock()
+        self._leader_state: dict = {"q7_l": None, "q7_r": None}
+        # Latest measured follower arm pose, published by the main loop for the
+        # input thread to shadow the leaders onto (no extra follower CAN reads).
+        self._shadow_target: dict = {"l": None, "r": None}
+        self._dagger_stop = threading.Event()
+        self._dagger_thread: Optional[threading.Thread] = None
+        # Per-physical-leader button edge state (either leader toggles).
+        self._last_btn = {"r": 0.0, "l": 0.0}
+        self._last_toggle_t = 0.0
+        # End-episode signal: a leader BOTTOM-button press sets this so the looped
+        # collector (run_session) finishes the current episode cleanly instead of
+        # Ctrl+C.  Ignored by single-rollout run() (end_on_button=False).
+        self._end_episode_evt = threading.Event()
+        self._last_btn_bottom = {"r": 0.0, "l": 0.0}
+        self._last_end_toggle_t = 0.0
+        self._episode_steps = 0
+        # Resolved once per session (DB task or fzf picker) by _resolve_dagger_task.
+        self._dagger_task_name: Optional[str] = None
+        self._dagger_instruction_resolved: str = ""
+
+        # Load model FIRST — this can take seconds (downloading weights, building
+        # the network) and doesn't need hardware.  Loading after robot init
+        # causes CAN timeouts on idle motor chains.
+        print(f"\nLoading model from {ckpt_path}...")
+        self._bridge.load(ckpt_path, **(bridge_kwargs or {}))
+        print("Model loaded.\n")
+
+        # Now initialize cameras, proprio threads, and robots (inherited).
+        # _wants_leaders() (overridden below) tells RaidenPolicyServer to also
+        # bring up the leader arms when intervening.  NOTE: with leaders enabled,
+        # the inherited __init__ home move also drives the leaders to home — keep
+        # hands OFF the leaders during startup.
+        super().__init__(**kwargs)
+
+        # rd serve wires the footpedal as a hard e-stop (attach_footpedal in the
+        # base __init__).  The infer loop must NOT inherit that: its only estops
+        # are _check_joint_delta (policy mode) + Ctrl+C, and a footpedal press
+        # must never kill a handback.  Detach it.
+        try:
+            if self._robot._footpedal is not None:
+                self._robot._footpedal.close()
+                self._robot._footpedal = None
+        except Exception:
+            pass
+
+        # Home the arms at startup.  The base server does NOT home in __init__
+        # (only its async reset(), which the local loop never calls), so drive
+        # the followers — and the leaders, when present — to home here so the
+        # rollout starts from a known pose.  With leaders enabled this also puts
+        # them at home so shadow mode has no startup jump.  Keep hands OFF.
+        print("Homing arms... (keep hands clear)")
+        self._robot.move_to_home_positions(simultaneous=True)
+
+        # Put leaders into their HG-DAgger startup mode AFTER the home move.
+        if self._intervene:
+            if self._leader_track:
+                # Shadow mode: keep the leaders PD-held (the inherited home move
+                # left non-zero gains in the command path).  The input thread will
+                # immediately drive them onto the followers — both start at home,
+                # so there is no startup jump.  Do NOT zero_torque here or the
+                # leaders would go limp until the first shadow command.
+                print(
+                    "HG-DAgger: leaders SHADOW the followers (under power). Press a "
+                    "leader trigger to take over (instant); press again to hand "
+                    "back. Keep hands clear until you take over.\n"
+                )
+            else:
+                # Static mode: leaders truly passive until takeover, then synced.
+                # Must use zero_torque_mode (not bare update_kp_kd): the home move
+                # latched non-zero gains into the command path and nothing commands
+                # the leader again in this loop, so update_kp_kd(0, 0) alone would
+                # never reach the motors (leader stays PD-locked at home).
+                if self._robot.leader_l is not None:
+                    self._robot.leader_l.zero_torque_mode()
+                if self._robot.leader_r is not None:
+                    self._robot.leader_r.zero_torque_mode()
+                print(
+                    "HG-DAgger: leaders passive. Press a leader trigger to toggle "
+                    "operator takeover (syncs leaders ~1.5 s); press again to hand "
+                    "back to the policy.\n"
+                )
+
+    # ------------------------------------------------------------------
+    # HG-DAgger hooks
+    # ------------------------------------------------------------------
+
+    def _wants_leaders(self) -> bool:
+        return self._intervene
+
+    def _dagger_input_loop(self) -> None:
+        """Daemon thread: owns ALL leader CAN I/O + button toggle detection.
+
+        ``YAMLeaderRobot.get_info()`` does a direct CAN read plus a ~10 ms sleep,
+        so it must never run in the 30 Hz main loop.  This is the SOLE owner of
+        the leader bus (reads AND shadow ``command_joint_pos`` writes) — the main
+        loop only ever reads a snapshot under the lock.  Concurrent read/write on
+        the leader bus from two threads throws mid-operation, which is why the
+        teardown joins this thread before the home move.
+        """
+        while not self._dagger_stop.is_set():
+            q7_l = q7_r = None
+            btn_l = btn_r = 0.0
+            btm_l = btm_r = 0.0
+            if self._robot.leader_l is not None:
+                try:
+                    q7_l, io_l = self._robot.leader_l.get_info()
+                    btn_l = float(io_l[0]) if len(io_l) > 0 else 0.0
+                    btm_l = float(io_l[1]) if len(io_l) > 1 else 0.0
+                except Exception:
+                    pass
+            if self._robot.leader_r is not None:
+                try:
+                    q7_r, io_r = self._robot.leader_r.get_info()
+                    btn_r = float(io_r[0]) if len(io_r) > 0 else 0.0
+                    btm_r = float(io_r[1]) if len(io_r) > 1 else 0.0
+                except Exception:
+                    pass
+
+            # Rising edge on either TOP trigger toggles the mode (0.3 s cooldown).
+            rising = (btn_r > 0.5 and self._last_btn["r"] < 0.5) or (
+                btn_l > 0.5 and self._last_btn["l"] < 0.5
+            )
+            self._last_btn["r"] = btn_r
+            self._last_btn["l"] = btn_l
+
+            now = time.monotonic()
+
+            # Rising edge on either BOTTOM button ends the current episode
+            # (consumed by run_session; ignored by single-rollout run()).
+            end_rising = (btm_r > 0.5 and self._last_btn_bottom["r"] < 0.5) or (
+                btm_l > 0.5 and self._last_btn_bottom["l"] < 0.5
+            )
+            self._last_btn_bottom["r"] = btm_r
+            self._last_btn_bottom["l"] = btm_l
+            if end_rising and (now - self._last_end_toggle_t) > 0.3:
+                self._last_end_toggle_t = now
+                self._end_episode_evt.set()
+                print("\n  [HG-DAgger] end-episode requested")
+
+            with self._mode_lock:
+                if q7_l is not None:
+                    self._leader_state["q7_l"] = q7_l
+                if q7_r is not None:
+                    self._leader_state["q7_r"] = q7_r
+                if rising and (now - self._last_toggle_t) > 0.3:
+                    self._last_toggle_t = now
+                    self._mode = "teleop" if self._mode == "policy" else "policy"
+                    print(f"\n  [HG-DAgger] -> {self._mode.upper()} mode")
+                mode_now = self._mode
+                tgt_l = self._shadow_target["l"]
+                tgt_r = self._shadow_target["r"]
+
+            # Shadow tracking: in POLICY mode, drive each leader onto the latest
+            # MEASURED follower pose so a later takeover is instant + seam-free.
+            # Commanding here (not the 30 Hz main loop) keeps all leader CAN I/O
+            # on this one thread.  Gated on policy: in teleop the leaders are
+            # zero_torque so the operator can move them.
+            if self._leader_track and mode_now == "policy":
+                if tgt_l is not None and self._robot.leader_l is not None:
+                    self._robot.leader_l.command_joint_pos(
+                        np.asarray(tgt_l[:6], dtype=np.float64)
+                    )
+                if tgt_r is not None and self._robot.leader_r is not None:
+                    self._robot.leader_r.command_joint_pos(
+                        np.asarray(tgt_r[:6], dtype=np.float64)
+                    )
+
+            time.sleep(0.005)
+
+    def _sync_leaders_to_followers(self) -> tuple:
+        """Drive each leader to its follower's arm pose, then re-passivate.
+
+        Static-mode takeover: the motorized leader is driven to the follower's
+        actual pose (instead of leaving it pinned at home) so the operator gets
+        full mechanical range around the follower configuration and the
+        subsequent absolute mirror is seam-free.  The leaders move UNDER POWER —
+        the operator must keep hands off during the sync.  Re-passivation goes
+        through ``zero_torque_mode`` (command path) so the leader ends up
+        genuinely free.
+
+        Returns ``(f0_l, f0_r)`` — the follower poses used as the sync targets,
+        which also become the follower baseline for the joint-delta takeover.
+        """
+        f0_l = (
+            self._robot.follower_l.get_joint_pos()
+            if self._robot.follower_l is not None
+            else None
+        )
+        f0_r = (
+            self._robot.follower_r.get_joint_pos()
+            if self._robot.follower_r is not None
+            else None
+        )
+
+        def _sync(leader, name: str, target: np.ndarray) -> None:
+            # Restore PD so the leader can be driven, interpolate to the follower
+            # arm pose, then go truly passive again via the command path.  NB:
+            # TRI's smooth_move_joints takes keyword args (its 3rd positional is
+            # start_joint_positions, not time_interval_s) — pass by keyword.
+            leader.update_kp_kd(
+                kp=self._robot.kp_gains[name], kd=self._robot.kd_gains[name]
+            )
+            smooth_move_joints(
+                leader._robot,
+                np.asarray(target[:6], dtype=np.float64),
+                time_interval_s=1.5,
+                steps=150,
+            )
+            leader.zero_torque_mode()
+
+        threads = []
+        if self._robot.leader_l is not None and f0_l is not None:
+            threads.append(
+                threading.Thread(
+                    target=_sync, args=(self._robot.leader_l, "leader_l", f0_l)
+                )
+            )
+        if self._robot.leader_r is not None and f0_r is not None:
+            threads.append(
+                threading.Thread(
+                    target=_sync, args=(self._robot.leader_r, "leader_r", f0_r)
+                )
+            )
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Let the input thread take at least one fresh post-sync leader reading
+        # before the caller snapshots leader_q0, so leader_q0 is in the same frame
+        # as subsequent live leader_now reads (otherwise the first step jumps).
+        time.sleep(0.1)
+
+        return (f0_l, f0_r)
+
+    def _rearm_leader_shadow(self) -> None:
+        """Restore leader PD gains so shadow tracking can drive them again.
+
+        Called on handback (teleop->policy) when ``leader_track`` is on: the
+        leaders were left in ``zero_torque_mode`` for the operator, so their gains
+        must be restored before the input thread's ``command_joint_pos`` can exert
+        torque (``update_kp_kd`` only sets ``_kp``; the next command stamps it into
+        the command path).
+
+        FIRST refresh ``_shadow_target`` to the followers' CURRENT measured pose,
+        THEN restore the gains.  The shadow target goes stale during teleop (only
+        published in policy mode); without this refresh the first shadow command
+        after re-arming would yank the leader toward the pre-intervention pose — a
+        visible jerk.  The followers are at the pose the human just left (≈ where
+        the leaders are), so targeting that makes the first shadow command a no-op.
+        """
+        with self._mode_lock:
+            if self._robot.follower_l is not None:
+                self._shadow_target["l"] = self._robot.follower_l.get_joint_pos()[:6]
+            if self._robot.follower_r is not None:
+                self._shadow_target["r"] = self._robot.follower_r.get_joint_pos()[:6]
+        if self._robot.leader_l is not None and "leader_l" in self._robot.kp_gains:
+            self._robot.leader_l.update_kp_kd(
+                kp=self._robot.kp_gains["leader_l"],
+                kd=self._robot.kd_gains["leader_l"],
+            )
+        if self._robot.leader_r is not None and "leader_r" in self._robot.kp_gains:
+            self._robot.leader_r.update_kp_kd(
+                kp=self._robot.kp_gains["leader_r"],
+                kd=self._robot.kd_gains["leader_r"],
+            )
+
+    def _make_dagger_recorder(self):
+        """Build a DaggerRecorder writing into the standard ``rd record`` layout."""
+        from raiden.recorder import DaggerRecorder, _next_recording_dir
+
+        if self._dagger_task_name is None:
+            self._resolve_dagger_task()
+        task_name = self._dagger_task_name
+        instruction = self._dagger_instruction_resolved
+
+        task_dir = Path(self._data_dir) / "raw" / task_name
+        task_dir.mkdir(parents=True, exist_ok=True)
+        rec_dir = _next_recording_dir(task_dir)
+        print(f"\n  Recording rollout -> {rec_dir}")
+        return DaggerRecorder(
+            cam_handles=self._cam_handles,
+            robot_controller=self._robot,
+            recording_dir=rec_dir,
+            task_name=task_name,
+            task_instruction=instruction,
+            camera_fps=30,
+        )
+
+    def _resolve_dagger_task(self) -> None:
+        """Resolve the dagger task name + instruction once (DB task or fzf picker)."""
+        from raiden.recorder import select_task
+
+        if self._dagger_task:
+            task_name = self._dagger_task
+            instruction = self._dagger_instruction or ""
+            if not instruction:
+                try:
+                    from raiden.db import get_db
+
+                    t = get_db().get_task_by_name(task_name)
+                    if t:
+                        instruction = t.get("instruction", "")
+                except Exception:
+                    pass
+        else:
+            task_name, instruction = select_task()
+        self._dagger_task_name = task_name
+        self._dagger_instruction_resolved = instruction
+
+    def _register_dagger_demo(self, rec_dir: Path, verdict: Optional[str]) -> None:
+        """Best-effort DB registration of a dagger rollout (tagged episode_kind).
+
+        Silently no-ops when the task is absent from the DB — dagger tasks
+        commonly have no DB rows by design.
+        """
+        try:
+            from raiden.db import get_db
+
+            db = get_db()
+            task = db.get_task_by_name(getattr(self, "_dagger_task_name", "") or "")
+            teachers = db.get_teachers()
+            if task is None or not teachers:
+                return
+            demo_id = db.add_demonstration(
+                teacher_id=teachers[-1]["id"],
+                task_id=task["id"],
+                raw_data_path=str(rec_dir),
+                camera_config_id=0,
+                calibration_result_id=None,
+            )
+            db.update_demonstration(
+                demo_id,
+                status=verdict or "pending",
+                converted=False,
+                episode_kind="dagger",
+            )
+        except Exception as exc:
+            print(f"  (DB registration skipped: {exc})")
+
+    # ------------------------------------------------------------------
+    # Single rollout
+    # ------------------------------------------------------------------
+
+    def _would_estop(self, action: np.ndarray) -> bool:
+        """Whether ``action`` would trip the base joint-delta safety check.
+
+        Mirrors :meth:`RaidenPolicyServer._check_joint_delta`'s threshold (arm
+        joints only, gripper excluded) so the leader-owning input thread can be
+        quiesced BEFORE the base's ``emergency_stop()`` drives the leaders on the
+        main thread.  A false positive at worst ends the session one step early.
+        """
+        pairs = []
+        if self._robot.follower_l:
+            q_l = self._read_proprio("follower_l_joint_pos")
+            if q_l is not None:
+                pairs.append((q_l, action[:DOF]))
+        if self._robot.follower_r:
+            q_r = self._read_proprio("follower_r_joint_pos")
+            if q_r is not None:
+                pairs.append((q_r, action[DOF : DOF * 2]))
+        for current, commanded in pairs:
+            if float(np.abs(commanded[:6] - current[:6]).max()) > self._max_joint_delta:
+                return True
+        return False
+
+    def _stop_input_thread(self) -> None:
+        """Stop + join the leader-CAN input thread so nothing else touches the
+        leader bus.  Idempotent (a no-op once already stopped)."""
+        self._dagger_stop.set()
+        t = getattr(self, "_dagger_thread", None)
+        if t is not None and t.is_alive():
+            t.join(timeout=1.0)
+
+    def run(self) -> None:
+        """Run the closed-loop inference loop.  Blocks until Ctrl+C.
+
+        In HG-DAgger mode (``intervene=True``) the policy runs autonomously until
+        the operator presses a leader trigger to take over, then presses again to
+        hand control back (a fresh ``bridge.reset()`` re-infer).  With shadow
+        tracking on (the default) the leaders continuously mirror the followers
+        during policy mode, so takeover is INSTANT and seam-free; with it off the
+        leaders sync to the followers (~1.5 s) at takeover.  Either way the
+        operator then drives via a joint-delta off the takeover baseline.  The
+        whole rollout is recorded with a per-frame ``control_source`` flag
+        (0=policy, 1=human) so ``rd convert`` / ``rd shardify`` can weight it.
+        """
+        dt = 1.0 / self._action_hz
+
+        self._maybe_reset_pose()
+        self._bridge.reset()
+
+        recorder = self._make_dagger_recorder() if self._record else None
+        if recorder is not None:
+            # Quiesce the ZED grab loops around enable_recording: a concurrent
+            # grab() + enable_recording() deadlocks the ZED SDK.  super().__init__
+            # has already started the grab threads, so start() MUST be guarded
+            # here just like run_session does.
+            self._pause_grabbing()
+            try:
+                recorder.start()
+            finally:
+                self._resume_grabbing()
+        if self._intervene:
+            self._dagger_thread = threading.Thread(
+                target=self._dagger_input_loop, name="dagger-input", daemon=True
+            )
+            self._dagger_thread.start()
+
+        print(f"Starting inference at {self._action_hz} Hz")
+        print("Press Ctrl+C to stop.\n")
+
+        verdict: Optional[str] = None
+        try:
+            self._episode_loop(recorder, dt, end_on_button=False)
+        finally:
+            self._teardown_run(recorder, verdict)
+
+    def _episode_loop(self, recorder, dt: float, end_on_button: bool = False) -> str:
+        """Run the per-step control loop for ONE episode.
+
+        Returns ``"ended"`` when the operator presses the end-episode (BOTTOM)
+        button (only when ``end_on_button``) or ``"interrupt"`` on Ctrl+C.  Shared
+        by :meth:`run` and :meth:`run_session` so autonomous + takeover behavior
+        is identical in both.
+        """
+        import os
+
+        step = 0
+        prev_mode = "policy"
+        # (follower_q0_l, follower_q0_r, leader_q0_l, leader_q0_r) at takeover edge.
+        takeover_q0: tuple = (None, None, None, None)
+        grip_engaged = {"l": False, "r": False}  # clutch latch, reset each takeover
+        prof_path = os.environ.get("RAIDEN_PROFILE")  # path or "1" → per-step timing
+        prof_rows = [] if prof_path else None
+        try:
+            while True:
+                if end_on_button and self._end_episode_evt.is_set():
+                    self._episode_steps = step
+                    return "ended"
+                t_step = time.perf_counter()
+
+                # Build observation from live sensors (synthetic step clock).
+                obs = self._make_obs(timestamp=step * dt)
+                # Expose the last COMMANDED joints so an eef bridge can rebase the
+                # next action chunk on the commanded (open-loop) pose rather than
+                # the measured (lagging) one — avoids the gravity-droop ratchet.
+                if self._last_joint_cmd is not None:
+                    _ljc = np.asarray(self._last_joint_cmd, dtype=np.float32)
+                    if _ljc.shape[0] >= DOF * 2:
+                        obs.proprios["follower_l_joint_cmd"] = _ljc[:DOF]
+                        obs.proprios["follower_r_joint_cmd"] = _ljc[DOF : DOF * 2]
+                _t_obs = time.perf_counter()
+                _t_pred0 = _t_pred1 = None
+
+                # Snapshot control mode + leader poses (filled by the input thread).
+                if self._intervene:
+                    with self._mode_lock:
+                        mode = self._mode
+                        leader_now = dict(self._leader_state)
+                else:
+                    mode, leader_now = "policy", {}
+
+                # Handle mode transitions on the edge.
+                if mode != prev_mode:
+                    if mode == "teleop":
+                        if self._leader_track:
+                            # Shadow tracking already kept the leaders ON the
+                            # followers, so takeover is INSTANT — just go passive
+                            # so the operator can move them, and capture the
+                            # baseline from the current (already-synced) read.
+                            if self._robot.leader_l is not None:
+                                self._robot.leader_l.zero_torque_mode()
+                            if self._robot.leader_r is not None:
+                                self._robot.leader_r.zero_torque_mode()
+                            f0_l = (
+                                self._robot.follower_l.get_joint_pos()
+                                if self._robot.follower_l
+                                else None
+                            )
+                            f0_r = (
+                                self._robot.follower_r.get_joint_pos()
+                                if self._robot.follower_r
+                                else None
+                            )
+                            print(
+                                "\n  [HG-DAgger] you have control (instant takeover).\n"
+                            )
+                        else:
+                            # Static mode: sync the motorized leaders to the
+                            # followers (blocking ~1.5 s). Hands OFF — leaders
+                            # move under power during the sync.
+                            print(
+                                "\n  [HG-DAgger] syncing leaders to followers — "
+                                "hands OFF the leaders..."
+                            )
+                            f0_l, f0_r = self._sync_leaders_to_followers()
+                            print("  [HG-DAgger] leaders synced — you have control.\n")
+                        # Capture the takeover baseline from the SAME read used for
+                        # this step's leader_now so the first joint-delta is exactly
+                        # zero (seam-free by construction).
+                        with self._mode_lock:
+                            leader_now = dict(self._leader_state)
+                        takeover_q0 = (
+                            f0_l,
+                            f0_r,
+                            leader_now.get("q7_l"),
+                            leader_now.get("q7_r"),
+                        )
+                        # Fresh gripper clutch for this takeover.
+                        grip_engaged = {"l": False, "r": False}
+                    else:
+                        # Handback: the policy resumes from the EXACT pose the
+                        # human left.  bridge.reset() discards the pre-intervention
+                        # chunk so the next predict() re-infers on the CURRENT obs.
+                        self._bridge.reset()
+                        if self._leader_track:
+                            # Re-arm shadow: restore leader PD so the input thread
+                            # can drive them again.  Followers are at the pose the
+                            # human left (≈ where the leaders are), so the first
+                            # shadow command is a tiny move, not a snap.
+                            self._rearm_leader_shadow()
+                    prev_mode = mode
+
+                if mode == "teleop":
+                    # Operator in control — joint-delta off the synced baseline
+                    # (arm becomes absolute mirroring; gripper uses a bumpless
+                    # clutch).  _check_joint_delta is SKIPPED in teleop: the human
+                    # is the safety authority, and running it would
+                    # emergency_stop()->os._exit on a large deliberate delta.
+                    action_14d = joint_delta_takeover(
+                        leader_now, takeover_q0, dof=DOF, grip_engaged=grip_engaged
+                    )
+                else:
+                    # Policy in control — observe and act from the current state.
+                    _t_pred0 = time.perf_counter()
+                    action = self._bridge.predict(obs)
+                    if self._action_type == "ee_pose":
+                        action_14d = self._ee_pose_to_joint_cmd(
+                            action, self._last_joint_cmd
+                        )
+                    else:
+                        action_14d = np.asarray(action, dtype=np.float32)
+                    # A policy-runaway breach here calls emergency_stop(), which
+                    # drives the LEADER bus from this (main) thread.  In intervene
+                    # mode the dagger input thread is the sole leader-bus owner, so
+                    # join it FIRST (only when an estop is actually imminent) or the
+                    # two race on the bus during the safety home move.
+                    if self._intervene and self._would_estop(action_14d):
+                        self._stop_input_thread()
+                    self._check_joint_delta(action_14d)
+                    _t_pred1 = time.perf_counter()
+
+                self._last_joint_cmd = action_14d
+
+                # Snapshot measured joints BEFORE commanding (the gap the PD must
+                # close), for delta logging + shadow publish.
+                meas_l = (
+                    self._robot.follower_l.get_joint_pos()
+                    if self._robot.follower_l
+                    else None
+                )
+                meas_r = (
+                    self._robot.follower_r.get_joint_pos()
+                    if self._robot.follower_r
+                    else None
+                )
+
+                # Publish the follower's MEASURED pose for the input thread to
+                # shadow the leaders onto (policy mode only).  We track measured —
+                # not the raw policy command — because the follower's damped PD has
+                # already smoothed the command; shadowing the raw command makes the
+                # differently-geared leader jitter while the follower stays smooth.
+                if self._intervene and self._leader_track and mode == "policy":
+                    with self._mode_lock:
+                        if meas_l is not None:
+                            self._shadow_target["l"] = meas_l[:6]
+                        if meas_r is not None:
+                            self._shadow_target["r"] = meas_r[:6]
+
+                # Command motors: action[:7] → left follower, action[7:14] → right.
+                _t_cmd0 = time.perf_counter()
+                if self._robot.follower_l:
+                    self._robot.follower_l.command_joint_pos(action_14d[:DOF])
+                if self._robot.follower_r:
+                    self._robot.follower_r.command_joint_pos(action_14d[DOF : DOF * 2])
+                _t_cmd1 = time.perf_counter()
+
+                # Record the rollout frame (observed obs + control_source flag +
+                # commanded joints).  Camera SDK clock so robot_ts aligns with the
+                # SVO2 frame timestamps.
+                if recorder is not None:
+                    recorder.add_frame(
+                        self._get_zed_current_time_ns(),
+                        self._robot.get_all_observations(),
+                        1 if mode == "teleop" else 0,
+                        action_14d,
+                    )
+
+                step += 1
+
+                # commanded-vs-measured delta per arm (6 arm joints only). A
+                # growing/plateauing delta near the torque ceiling is a
+                # contact / no-progress signal.
+                delta_l = (
+                    np.abs(action_14d[:6] - meas_l[:6]) if meas_l is not None else None
+                )
+                delta_r = (
+                    np.abs(action_14d[DOF : DOF + 6] - meas_r[:6])
+                    if meas_r is not None
+                    else None
+                )
+
+                elapsed = time.perf_counter() - t_step
+                hz = 1.0 / max(elapsed, 1e-6)
+                tag = "HUMAN" if mode == "teleop" else "policy"
+                l_act = np.array2string(
+                    action_14d[:DOF], precision=3, suppress_small=True
+                )
+                r_act = np.array2string(
+                    action_14d[DOF : DOF * 2], precision=3, suppress_small=True
+                )
+                if step % 5 == 1:
+                    dl = f"max={delta_l.max():.3f}" if delta_l is not None else "n/a"
+                    dr = f"max={delta_r.max():.3f}" if delta_r is not None else "n/a"
+                    print(
+                        f"step={step:5d}  hz={hz:.1f}  [{tag}]  "
+                        f"l_delta[{dl}]  r_delta[{dr}]"
+                    )
+                else:
+                    print(f"step={step:5d}  hz={hz:.1f}  [{tag}]  l={l_act}  r={r_act}")
+
+                # Sleep to maintain target Hz.
+                elapsed = time.perf_counter() - t_step
+                remaining = dt - elapsed
+                if prof_rows is not None:
+                    prof_rows.append(
+                        {
+                            "step": step,
+                            "mode": mode,
+                            "obs_ms": round((_t_obs - t_step) * 1e3, 3),
+                            "predict_ms": (
+                                round((_t_pred1 - _t_pred0) * 1e3, 3)
+                                if _t_pred0 is not None and _t_pred1 is not None
+                                else None
+                            ),
+                            "cmd_ms": round((_t_cmd1 - _t_cmd0) * 1e3, 3),
+                            "work_ms": round(elapsed * 1e3, 3),
+                            "cmd": [round(float(x), 4) for x in action_14d],
+                        }
+                    )
+                if remaining > 0:
+                    time.sleep(remaining)
+
+        except KeyboardInterrupt:
+            print("\n\nStopping inference...")
+            self._episode_steps = step
+            return "interrupt"
+        finally:
+            if prof_rows:
+                import json
+
+                _out = (
+                    "policy_profile.jsonl"
+                    if prof_path in ("1", "true", "True")
+                    else prof_path
+                )
+                _n = getattr(self, "_prof_ep_idx", 0)
+                self._prof_ep_idx = _n + 1
+                if _n:
+                    _root, _ext = os.path.splitext(_out)
+                    _out = f"{_root}.ep{_n}{_ext}"
+                try:
+                    with open(_out, "w") as _f:
+                        for _r in prof_rows:
+                            _f.write(json.dumps(_r) + "\n")
+                    print(f"\n[profile] wrote {len(prof_rows)} steps -> {_out}")
+                except Exception as _exc:
+                    print(f"[profile] dump failed: {_exc}")
+
+    def _teardown_run(self, recorder, verdict) -> None:
+        """Home + de-energize + save — teardown for the single-rollout run().
+
+        ORDER IS LOAD-BEARING.  (1) Stop + JOIN the input thread first: it owns
+        all leader CAN I/O and must be quiet before the home move drives the
+        leaders (concurrent read/write on the leader bus throws mid-home).  (2)
+        Drive home while CAN is healthy (restoring leader PD first so zero_torque
+        leaders don't sag).  (3) close() to de-energize FROM home.  (4) ONLY THEN
+        the heavy recorder.stop() (SVO2 flush + np.savez of thousands of frames)
+        — deferred because it hogs the GIL for seconds and would starve the
+        100/250 Hz motor threads past the ~400 ms DM watchdog and drop every CAN
+        bus.  Doing it after close() means there are no motor threads left to
+        starve.  (5) DB registration.  (6) bridge.reset().  (7) close cameras.
+        """
+        step = self._episode_steps
+
+        # (1) quiet the leader bus before homing.  The join MUST complete: a live
+        # input thread owns the leader bus and the home move below drives it too.
+        # 2 s is ~200 input-loop iterations of margin (it re-checks the stop flag
+        # every ~10 ms), so a surviving thread means a genuinely wedged CAN read.
+        self._dagger_stop.set()
+        if self._dagger_thread is not None:
+            self._dagger_thread.join(timeout=2.0)
+            if self._dagger_thread.is_alive():
+                print(
+                    "  Warning: leader input thread did not stop within 2 s "
+                    "(wedged CAN read?). The home move below may contend with it "
+                    "on the leader bus — keep clear of the arms."
+                )
+
+        # (2) home while CAN is healthy.
+        if step > 0:
+            print("Returning to home... (keep hands clear of the arms)")
+            try:
+                if self._intervene:
+                    # Leaders may be in zero_torque_mode (static, or post-takeover)
+                    # — restore PD first or move_to_home commands them with zero
+                    # gains and they sag.  Guarded so a CAN error still falls
+                    # through to close() rather than crashing.
+                    self._robot.disable_gravity_compensation()
+                self._robot.move_to_home_positions(simultaneous=True)
+            except Exception as exc:
+                print(f"  (home move error: {exc})")
+
+        # (3) stop capture loops + de-energize FROM home.  Setting _running=False
+        # also stops the ZED grab loops, so the subsequent recorder.stop()
+        # disable_recording cannot deadlock against a live grab().
+        self._running = False
+        time.sleep(0.1)
+        try:
+            self._robot.close()
+        except Exception as exc:
+            print(f"  (robot close error: {exc})")
+
+        # (4) arms are safe — persist the rollout (heavy) and clean up.
+        try:
+            if recorder is not None and recorder.is_recording:
+                rec_dir = recorder.stop(complete=True, verdict=verdict)
+                if self._intervene:
+                    self._register_dagger_demo(rec_dir, verdict)
+        except Exception as exc:
+            print(f"  (recording shutdown error: {exc})")
+        # (6) bridge reset.
+        try:
+            self._bridge.reset()
+        except Exception:
+            pass
+        # (7) close cameras.
+        for handle in self._cam_handles.values():
+            try:
+                if handle.get("type") == "zed":
+                    handle["camera"].close()
+                elif "pipeline" in handle:
+                    handle["pipeline"].stop()
+            except Exception:
+                pass
+        print("Done.")
+
+    # ------------------------------------------------------------------
+    # Looped HG-DAgger collection (reuses model/cameras/robot)
+    # ------------------------------------------------------------------
+
+    def run_session(self) -> None:
+        """Looped HG-DAgger collection — episode after episode in one process.
+
+        The model, cameras, and robot load ONCE; every episode reuses them.  Per
+        episode: a start gate (reset the scene) -> the policy runs autonomously
+        (leader TOP button to take over, again to hand back) -> leader BOTTOM
+        button to end -> keyboard ``s``/``d`` to save or discard -> next episode.
+        ``q`` at the gate, or Ctrl+C mid-episode, ends the session.
+        """
+        dt = 1.0 / self._action_hz
+        self._maybe_reset_pose()
+        self._resolve_dagger_task()
+
+        print(f"\n=== HG-DAgger session — task '{self._dagger_task_name}' ===")
+        episode_idx = 0
+        try:
+            while True:
+                if not self._wait_for_episode_start(episode_idx):
+                    break
+
+                self._bridge.reset()
+                self._last_joint_cmd = None
+                self._mode = "policy"
+                self._end_episode_evt.clear()
+                recorder = self._make_dagger_recorder()
+                # Quiesce the grab threads around the SVO2 enable toggle (they run
+                # continuously between episodes; concurrent grab()+enable_recording
+                # deadlocks the ZED SDK).
+                self._pause_grabbing()
+                try:
+                    recorder.start()
+                finally:
+                    self._resume_grabbing()
+
+                # The leader-input thread runs ONLY during the episode.
+                if self._intervene:
+                    self._dagger_stop.clear()
+                    self._dagger_thread = threading.Thread(
+                        target=self._dagger_input_loop, name="dagger-input", daemon=True
+                    )
+                    self._dagger_thread.start()
+
+                print(
+                    f"\nEpisode running at {self._action_hz} Hz   "
+                    "[TOP = take over / hand back   BOTTOM = end episode]\n"
+                )
+                reason = self._episode_loop(recorder, dt, end_on_button=True)
+
+                # Quiet the leader bus (stop shadow-driving) before homing so the
+                # input thread doesn't fight the home move on the same bus.
+                self._dagger_stop.set()
+                if self._dagger_thread is not None:
+                    self._dagger_thread.join(timeout=1.0)
+                    self._dagger_thread = None
+
+                # Home + DISCONNECT all four CAN buses BEFORE finalizing the
+                # recording — mirrors DemonstrationRecorder.stop_recording, which
+                # closes motors THEN saves.  With CAN already closed the heavy
+                # SVO2 flush + np.savez can't starve the motor threads past the DM
+                # watchdog and drop the bus.
+                self._robot.return_to_home_and_disconnect()
+
+                # Now safe to stop SVO2 + write robot_data.npz.  Pause grabbing
+                # around stop() for the grab()-vs-disable_recording deadlock.
+                self._pause_grabbing()
+                try:
+                    rec_dir = recorder.stop(complete=True, verdict=None)
+                finally:
+                    self._resume_grabbing()
+
+                if reason == "interrupt":
+                    # Ctrl+C ends the whole session; keep the in-progress episode
+                    # and skip the re-init.
+                    self._register_dagger_demo(rec_dir, None)
+                    print(f"  Saved -> {rec_dir}")
+                    break
+                if self._wait_for_save_or_discard():
+                    self._register_dagger_demo(rec_dir, None)
+                    print(f"  Saved -> {rec_dir}")
+                else:
+                    shutil.rmtree(rec_dir, ignore_errors=True)
+                    print("  Discarded.")
+
+                # Re-open CAN + re-home + restore the leader mode for the next
+                # episode (mirrors rd record between episodes).
+                self._reinit_robot_for_next_episode()
+                episode_idx += 1
+        finally:
+            self._shutdown_session()
+
+    def _reinit_robot_for_next_episode(self) -> None:
+        """Re-open CAN, re-home, and restore the dagger leader mode for next episode.
+
+        ``return_to_home_and_disconnect()`` closed every CAN bus and nulled the
+        arm handles.  ``initialize_robots()`` recreates each arm from scratch and
+        re-opens its bus; drive them home, then put the leaders back into shadow
+        (leader_track) or passive (static) mode — the state the constructor left.
+        """
+        print("\nRe-initializing arms for the next episode... (hands clear)")
+        self._robot.check_can_interfaces()
+        self._robot.initialize_robots()
+        self._robot.move_to_home_positions(simultaneous=True)
+        if self._intervene:
+            if self._leader_track:
+                self._rearm_leader_shadow()
+            else:
+                if self._robot.leader_l is not None:
+                    self._robot.leader_l.zero_torque_mode()
+                if self._robot.leader_r is not None:
+                    self._robot.leader_r.zero_torque_mode()
+
+    def _pause_grabbing(self) -> None:
+        """Quiesce the camera grab threads before toggling SVO2 recording."""
+        evt = getattr(self, "_grab_paused", None)
+        if evt is not None:
+            evt.set()
+            time.sleep(0.15)  # let any in-flight grab() (~33 ms at 30 fps) finish
+
+    def _resume_grabbing(self) -> None:
+        evt = getattr(self, "_grab_paused", None)
+        if evt is not None:
+            evt.clear()
+
+    def _shutdown_session(self) -> None:
+        """Stop the input thread, de-energize the arms, close cameras."""
+        self._dagger_stop.set()
+        if self._dagger_thread is not None:
+            self._dagger_thread.join(timeout=1.0)
+        self._running = False
+        time.sleep(0.1)
+        try:
+            self._robot.close()
+        except Exception as exc:
+            print(f"  (robot close error: {exc})")
+        try:
+            self._bridge.reset()
+        except Exception:
+            pass
+        for handle in self._cam_handles.values():
+            try:
+                if handle.get("type") == "zed":
+                    handle["camera"].close()
+                elif "pipeline" in handle:
+                    handle["pipeline"].stop()
+            except Exception:
+                pass
+        print("Session done.")
+
+    def _wait_for_episode_start(self, episode_idx: int) -> bool:
+        """Gate before each episode.  Enter -> start, q -> quit the session."""
+        import select
+        import sys
+        import termios
+        import tty
+
+        print("\n" + "=" * 60)
+        print(
+            f"  Ready for episode #{episode_idx}.  Reset the scene, then:\n"
+            "    Enter -> start    q -> quit session"
+        )
+        print("=" * 60)
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setcbreak(fd)
+            while True:
+                if select.select([sys.stdin], [], [], 0)[0]:
+                    ch = sys.stdin.read(1)
+                    if ch.lower() == "q":
+                        return False
+                    if ch in ("\r", "\n"):
+                        return True
+                time.sleep(0.05)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+    def _wait_for_save_or_discard(self) -> bool:
+        """After an episode ends: s -> save, d -> discard (keyboard only)."""
+        import select
+        import sys
+        import termios
+        import tty
+
+        print("\n" + "-" * 60)
+        print("  Keep this episode?   s -> save    d -> discard")
+        print("-" * 60)
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setcbreak(fd)
+            while True:
+                if select.select([sys.stdin], [], [], 0)[0]:
+                    ch = sys.stdin.read(1).lower()
+                    if ch == "s":
+                        return True
+                    if ch == "d":
+                        return False
+                time.sleep(0.05)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+    def _maybe_reset_pose(self) -> None:
+        """Optionally move the followers to a saved pose before the rollout.
+
+        Opt-in via ``--reset-pose``; moves to the first frame of a saved
+        ``robot_data.npz`` (per ABC, resetting is discouraged — prefer
+        intervene-and-continue — hence off by default).
+        """
+        if not self._reset_pose:
+            return
+        try:
+            from raiden.robot.replay import _load_raw_joints
+
+            joints_l, joints_r, _ = _load_raw_joints(Path(self._reset_pose))
+            print(f"\nResetting to first-frame pose from {self._reset_pose}...")
+            threads = []
+            if self._robot.follower_l is not None and joints_l is not None:
+                threads.append(
+                    threading.Thread(
+                        target=smooth_move_joints,
+                        args=(self._robot.follower_l, joints_l[0]),
+                    )
+                )
+            if self._robot.follower_r is not None and joints_r is not None:
+                threads.append(
+                    threading.Thread(
+                        target=smooth_move_joints,
+                        args=(self._robot.follower_r, joints_r[0]),
+                    )
+                )
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        except Exception as exc:
+            print(f"  (reset-pose skipped: {exc})")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic bridge loading (used by ``rd infer``)
+# ---------------------------------------------------------------------------
+
+
+def load_bridge(bridge_spec: str, **kwargs) -> ModelBridge:
+    """Import a ModelBridge class from a ``module.path:ClassName`` string.
+
+    Extra *kwargs* are forwarded to the bridge constructor.
+
+    Examples::
+
+        load_bridge("your_model.deployment.yam_bridge:MyBridge")
+        load_bridge("your_model.deployment.yam_bridge:MyBridge", chunk_size=4)
+    """
+    if ":" not in bridge_spec:
+        raise ValueError(
+            f"Bridge spec must be 'module.path:ClassName', got '{bridge_spec}'"
+        )
+    module_path, class_name = bridge_spec.rsplit(":", 1)
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            f"Cannot import bridge module '{module_path}'. "
+            "Make sure it is installed or on PYTHONPATH."
+        ) from exc
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        raise AttributeError(f"Module '{module_path}' has no attribute '{class_name}'")
+    bridge = cls(**kwargs)
+    if not isinstance(bridge, ModelBridge):
+        raise TypeError(f"'{bridge_spec}' is not a ModelBridge subclass")
+    return bridge

--- a/raiden/inspector.py
+++ b/raiden/inspector.py
@@ -1,0 +1,549 @@
+"""Pre-flight quality check for raw SVO2 recordings — flag frame-stutter and
+left-eye blackouts before ``rd convert``.
+
+Reads each frame's capture timestamp from every ``cameras/*.svo2`` file and, for
+the stereo LEFT view only, checks whether the frame is fully black.  The LEFT
+view is the one ``rd convert`` turns into training RGB
+(:meth:`raiden.cameras.zed.ZedCamera.get_frame` retrieves ``sl.VIEW.LEFT``), so a
+black left eye corrupts the data even when the right eye and frame timing are
+perfectly healthy — a failure the timestamp scan alone cannot see.
+
+Stutter matters because :func:`raiden.robot.replay._solve_ik_sequence` treats
+processed lowdim files as uniformly-spaced 30 Hz keyframes (``np.arange``-based
+indexing).  Any real-time gap between consecutive surviving frames therefore
+collapses to a single 1/30 s replay step, producing visible bursts of
+unphysical speed during ``rd replay`` and silently distorting the action labels
+a policy learns from.
+
+All camera views (``cameras/*.svo2`` — e.g. ``scene_camera``,
+``left_wrist_camera``, ``right_wrist_camera``) of each episode are scanned, since
+wrist cameras sometimes drop or lose frames independently of the scene camera.
+The views of one episode are scanned concurrently (one thread per view).  The
+check is camera-name agnostic: any directory containing a ``cameras/`` folder
+with at least one ``.svo2`` file is treated as an episode.
+
+Caching
+-------
+Each scanned episode gets its own ``<episode_dir>/inspect.json`` cache file
+holding one entry per camera, each keyed by that camera's SVO2 mtime.  Re-runs
+only re-scan the views whose ``.svo2`` has changed since the cache was written
+(or are missing from the cache entirely).  The task-level
+``<task_dir>/inspect_report.json`` is a derived aggregate, rebuilt from the
+per-episode files on every run.
+"""
+
+import concurrent.futures
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# ── verdict thresholds ────────────────────────────────────────────────────────
+# ``shrink`` = real elapsed duration / ideal 30 Hz replay duration.  A value of
+# 1.0 means the recording ran at exactly 30 Hz; larger means frames were dropped
+# and the surviving ones will play back too fast.
+CLEAN_SHRINK = 1.05
+BORDERLINE_SHRINK = 1.10
+BAD_SHRINK = 1.20
+CLEAN_MAX_DT_MS = 200.0
+BORDERLINE_MAX_DT_MS = 1000.0
+BAD_MAX_DT_MS = 2000.0
+MIN_FRAMES = 10
+
+# A view whose frame count falls below this fraction of the episode's busiest
+# view is flagged as having dropped/missing frames (cameras grab in lock-step at
+# 30 Hz, so a large discrepancy means one view lost frames).
+FRAME_DROP_RATIO = 0.95
+
+# Left-eye blackout detection. A frame is "black" when its MEAN brightness across
+# the RGB channels is at/below BLACK_MEAN_MAX. A dead left eye (sensor dropout)
+# sits uniformly at the noise floor (~3/255), while even a dim real scene means in
+# the tens-to-hundreds — a ~25x separation. We use the mean, not the per-pixel
+# max: a visually-black frame still carries read noise and stray hot pixels whose
+# raw channel values routinely exceed any low cutoff, so a max-based test silently
+# misses real blackouts. A view is flagged once more than BLACK_RATIO of its
+# frames are black.
+BLACK_MEAN_MAX = 10.0
+BLACK_RATIO = 0.10
+
+# The LEFT view is retrieved downscaled to this resolution purely to measure mean
+# brightness. A black frame is black at any resolution, so downscaling keeps the
+# per-frame check on EVERY frame (no temporal sampling — a blackout starting
+# anywhere is caught) while cutting its cost ~8x: full-res adds ~190% to the scan,
+# this adds ~25%, since the unavoidable per-frame ``grab`` decode dominates.
+BLACK_CHECK_WIDTH = 320
+BLACK_CHECK_HEIGHT = 180
+
+VERDICT_RANK = {
+    "clean": 0,
+    "borderline": 1,
+    "bad": 2,
+    "broken": 3,
+    "black": 4,
+    "missing": 5,
+}
+
+EPISODE_CACHE_NAME = "inspect.json"
+TASK_REPORT_NAME = "inspect_report.json"
+
+# Default concurrent SVO2 scans. Each scan is a decode loop that releases the GIL
+# during ``grab``, but the ZED SDK saturates around 8 concurrent decodes (more
+# threads only open extra cameras for no throughput gain), so cap the default
+# there. Override with ``--workers`` for unusual hardware.
+DEFAULT_SCAN_WORKERS = 8
+
+
+def _default_workers() -> int:
+    return min(os.cpu_count() or 4, DEFAULT_SCAN_WORKERS)
+
+
+def _is_episode_dir(d: Path) -> bool:
+    """An episode is any directory holding a ``cameras/`` folder with ≥1 ``.svo2``."""
+    cam_dir = d / "cameras"
+    return d.is_dir() and cam_dir.is_dir() and any(cam_dir.glob("*.svo2"))
+
+
+@dataclass
+class InspectResult:
+    n_frames: int
+    sdk_total_frames: int
+    n_grab_errors: int
+    n_black_frames: int
+    black_ratio: float
+    median_dt_ms: float
+    mean_dt_ms: float
+    max_dt_ms: float
+    p99_dt_ms: float
+    gaps_over_50ms: int
+    gaps_over_100ms: int
+    gaps_over_500ms: int
+    real_duration_s: float
+    replay_duration_s: float
+    shrink: float
+    worst_burst_at_replay_s: float
+    verdict: str
+    svo2_mtime_ns: int
+
+
+def _scan_svo2(svo_path: Path) -> Tuple[np.ndarray, int, int, int]:
+    """Walk an SVO2 file, collecting per-frame timestamps and left-eye blackouts.
+
+    Returns ``(timestamps_ns, sdk_total_frames, n_grab_errors, n_black_frames)``.
+    ``n_black_frames`` counts frames whose stereo LEFT view — the eye
+    ``rd convert`` writes to training RGB — is black (mean RGB brightness
+    ``<= BLACK_MEAN_MAX``).  ``pyzed`` is imported lazily so ``rd inspect
+    --help`` works on machines without the SDK.
+    """
+    import pyzed.sl as sl
+
+    cam = sl.Camera()
+    init = sl.InitParameters()
+    init.set_from_svo_file(str(svo_path))
+    init.svo_real_time_mode = False
+    init.depth_mode = sl.DEPTH_MODE.NONE
+    init.coordinate_units = sl.UNIT.METER
+    # We read frame timestamps and the LEFT image only — skip depth (above),
+    # self-calibration and sensor ingest to cut per-file overhead (matters when
+    # scanning hundreds of episodes).
+    init.camera_disable_self_calib = True
+    init.sensors_required = False
+
+    err = cam.open(init)
+    if err != sl.ERROR_CODE.SUCCESS:
+        raise RuntimeError(f"Failed to open {svo_path}: {err}")
+
+    sdk_total = cam.get_svo_number_of_frames()
+    runtime = sl.RuntimeParameters()
+    left = sl.Mat()
+    low_res = sl.Resolution(BLACK_CHECK_WIDTH, BLACK_CHECK_HEIGHT)
+    ts: List[int] = []
+    n_errors = 0
+    n_black = 0
+    try:
+        while True:
+            err = cam.grab(runtime)
+            if err == sl.ERROR_CODE.END_OF_SVOFILE_REACHED:
+                break
+            if err != sl.ERROR_CODE.SUCCESS:
+                n_errors += 1
+                continue
+            ts.append(cam.get_timestamp(sl.TIME_REFERENCE.IMAGE).get_nanoseconds())
+            # Same eye convert uses (VIEW.LEFT), downscaled — RGB channels only
+            # (get_data() is H x W x 4 BGRA; drop alpha).
+            cam.retrieve_image(left, sl.VIEW.LEFT, sl.MEM.CPU, low_res)
+            if left.get_data()[:, :, :3].mean() <= BLACK_MEAN_MAX:
+                n_black += 1
+    finally:
+        left.free()
+        cam.close()
+
+    return np.asarray(ts, dtype=np.int64), int(sdk_total), n_errors, n_black
+
+
+def _classify(shrink: float, max_dt_ms: float, n_frames: int) -> str:
+    if n_frames < MIN_FRAMES or shrink > BAD_SHRINK or max_dt_ms > BAD_MAX_DT_MS:
+        return "broken"
+    if shrink > BORDERLINE_SHRINK or max_dt_ms > BORDERLINE_MAX_DT_MS:
+        return "bad"
+    if shrink > CLEAN_SHRINK or max_dt_ms > CLEAN_MAX_DT_MS:
+        return "borderline"
+    return "clean"
+
+
+def _result_from_scan(
+    ts: np.ndarray,
+    sdk_total: int,
+    n_errors: int,
+    n_black: int,
+    svo_mtime_ns: int,
+) -> InspectResult:
+    """Turn a raw SVO2 scan into a classified :class:`InspectResult`.
+
+    Split out from :func:`_analyze_svo` so the (pure) classification maths can be
+    unit-tested without the ZED SDK.
+    """
+    n = len(ts)
+    if n < 2:
+        return InspectResult(
+            n_frames=n,
+            sdk_total_frames=sdk_total,
+            n_grab_errors=n_errors,
+            n_black_frames=n_black,
+            black_ratio=float(n_black / n) if n else 0.0,
+            median_dt_ms=0.0,
+            mean_dt_ms=0.0,
+            max_dt_ms=0.0,
+            p99_dt_ms=0.0,
+            gaps_over_50ms=0,
+            gaps_over_100ms=0,
+            gaps_over_500ms=0,
+            real_duration_s=0.0,
+            replay_duration_s=0.0,
+            shrink=0.0,
+            worst_burst_at_replay_s=0.0,
+            verdict="broken",
+            svo2_mtime_ns=svo_mtime_ns,
+        )
+
+    dt_ms = np.diff(ts) / 1e6
+    real_s = float((ts[-1] - ts[0]) / 1e9)
+    replay_s = (n - 1) / 30.0
+    shrink = real_s / replay_s if replay_s > 0 else 0.0
+    max_dt = float(dt_ms.max())
+    black_ratio = n_black / n
+
+    # A black left eye corrupts the training data outright, so it overrides the
+    # (orthogonal) timing verdict — the timing metrics stay in the result either
+    # way for diagnosis.
+    verdict = "black" if black_ratio > BLACK_RATIO else _classify(shrink, max_dt, n)
+
+    return InspectResult(
+        n_frames=n,
+        sdk_total_frames=sdk_total,
+        n_grab_errors=n_errors,
+        n_black_frames=n_black,
+        black_ratio=float(black_ratio),
+        median_dt_ms=float(np.median(dt_ms)),
+        mean_dt_ms=float(np.mean(dt_ms)),
+        max_dt_ms=max_dt,
+        p99_dt_ms=float(np.percentile(dt_ms, 99)),
+        gaps_over_50ms=int(np.sum(dt_ms > 50)),
+        gaps_over_100ms=int(np.sum(dt_ms > 100)),
+        gaps_over_500ms=int(np.sum(dt_ms > 500)),
+        real_duration_s=real_s,
+        replay_duration_s=replay_s,
+        shrink=float(shrink),
+        worst_burst_at_replay_s=float(int(dt_ms.argmax())) / 30.0,
+        verdict=verdict,
+        svo2_mtime_ns=svo_mtime_ns,
+    )
+
+
+def _analyze_svo(svo_path: Path) -> InspectResult:
+    svo_mtime_ns = svo_path.stat().st_mtime_ns
+    ts, sdk_total, n_errors, n_black = _scan_svo2(svo_path)
+    return _result_from_scan(ts, sdk_total, n_errors, n_black, svo_mtime_ns)
+
+
+def _episode_svo_paths(episode_dir: Path) -> Dict[str, Path]:
+    """Map ``camera_name -> svo2_path`` for every view present in the episode."""
+    cam_dir = episode_dir / "cameras"
+    return {p.stem: p for p in sorted(cam_dir.glob("*.svo2"))}
+
+
+def _load_episode_cache(episode_dir: Path, force: bool) -> Dict[str, InspectResult]:
+    """Return the per-camera cached results that are still fresh.
+
+    A camera's entry is fresh when its ``svo2_mtime_ns`` matches the current
+    ``.svo2`` mtime.  Cameras with stale/absent entries are omitted (forcing a
+    rescan of just those views).  ``force``, a missing/corrupt cache, or an
+    old flat-schema cache all yield ``{}`` (full rescan).
+    """
+    if force:
+        return {}
+    cache_path = episode_dir / EPISODE_CACHE_NAME
+    if not cache_path.exists():
+        return {}
+    try:
+        cached = json.loads(cache_path.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+    svo_paths = _episode_svo_paths(episode_dir)
+    fresh: Dict[str, InspectResult] = {}
+    for cam, entry in cached.items():
+        if not isinstance(entry, dict):
+            return {}  # legacy flat-schema cache — rescan everything
+        svo = svo_paths.get(cam)
+        if svo is None:
+            continue
+        try:
+            r = InspectResult(**entry)
+        except (TypeError, KeyError):
+            continue
+        if r.svo2_mtime_ns == svo.stat().st_mtime_ns:
+            fresh[cam] = r
+    return fresh
+
+
+def _save_episode_cache(episode_dir: Path, results: Dict[str, InspectResult]) -> None:
+    cache_path = episode_dir / EPISODE_CACHE_NAME
+    cache_path.write_text(
+        json.dumps({cam: asdict(r) for cam, r in results.items()}, indent=2)
+    )
+
+
+def _frame_drops(views: Dict[str, InspectResult]) -> set:
+    """Cameras whose frame count is anomalously low vs the busiest view."""
+    if len(views) < 2:
+        return set()
+    ref = max(r.n_frames for r in views.values())
+    if ref <= 0:
+        return set()
+    return {cam for cam, r in views.items() if r.n_frames < ref * FRAME_DROP_RATIO}
+
+
+def _episode_verdict(
+    views: Dict[str, InspectResult], drops: set, missing: List[str]
+) -> str:
+    """Worst per-view verdict, escalated for dropped or missing views."""
+    verdicts = [r.verdict for r in views.values()]
+    if drops:
+        verdicts.append("bad")
+    if missing:
+        verdicts.append("missing")
+    if not verdicts:
+        return "missing"
+    return max(verdicts, key=lambda v: VERDICT_RANK.get(v, 0))
+
+
+def _print_table(items: List[Tuple[str, Dict]]) -> None:
+    header = (
+        f"{'ep':>5} {'cam':>18} {'n':>5} {'med':>6} {'max':>8} {'p99':>7} "
+        f"{'g>50':>5} {'g>100':>6} {'g>500':>6} {'blk%':>6} {'shrink':>7} "
+        f"{'verdict':>11} {'flag':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    for ep_id, ep in items:
+        views: Dict[str, InspectResult] = ep["views"]
+        drops: set = ep["drops"]
+        missing: List[str] = ep["missing"]
+        first = True
+        for cam in sorted(views):
+            r = views[cam]
+            flag = "BLACK" if r.verdict == "black" else "DROP" if cam in drops else ""
+            print(
+                f"{ep_id if first else '':>5} {cam:>18} {r.n_frames:>5} "
+                f"{r.median_dt_ms:>6.2f} {r.max_dt_ms:>8.1f} {r.p99_dt_ms:>7.1f} "
+                f"{r.gaps_over_50ms:>5} {r.gaps_over_100ms:>6} {r.gaps_over_500ms:>6} "
+                f"{r.black_ratio * 100:>5.1f}% {r.shrink:>6.2f}x {r.verdict:>11} {flag:>8}"
+            )
+            first = False
+        for cam in missing:
+            print(
+                f"{ep_id if first else '':>5} {cam:>18} "
+                f"{'-':>5} {'-':>6} {'-':>8} {'-':>7} "
+                f"{'-':>5} {'-':>6} {'-':>6} {'-':>6} {'-':>7} "
+                f"{'missing':>11} {'MISSING':>8}"
+            )
+            first = False
+
+
+def inspect_task(
+    task_dir: Path, force: bool = False, workers: Optional[int] = None
+) -> Dict:
+    """Inspect every episode in a task, print a per-episode table, and save report.
+
+    Per-camera results are cached at ``<episode>/inspect.json`` (each entry
+    mtime-keyed against its ``.svo2``); only changed/uncached views are
+    rescanned.  Every view that needs a scan — across all episodes — runs in a
+    single shared thread pool (``workers`` threads, default
+    :func:`_default_workers`), so scans overlap across episodes rather than one
+    episode at a time.  The task-level ``inspect_report.json`` aggregate is
+    rebuilt from the per-episode files on every run.
+    """
+    task_dir = Path(task_dir)
+    ep_dirs = sorted(d for d in task_dir.iterdir() if _is_episode_dir(d))
+    if not ep_dirs:
+        print(f"No episodes with cameras/*.svo2 found in {task_dir}")
+        return {}
+
+    print(f"Task: {task_dir.name}  ({len(ep_dirs)} episodes)\n")
+
+    # Reuse fresh per-camera cache, then flatten every view still needing a scan
+    # — across all episodes — into one job list so the whole task fills a single
+    # shared thread pool instead of scanning one episode at a time.
+    ep_by_id = {d.name: d for d in ep_dirs}
+    raw: Dict[str, Dict[str, InspectResult]] = {}
+    jobs: List[Tuple[str, str, Path]] = []
+    for ep_dir in ep_dirs:
+        cached = _load_episode_cache(ep_dir, force=force)
+        raw[ep_dir.name] = dict(cached)
+        for cam, svo in _episode_svo_paths(ep_dir).items():
+            if cam not in cached:
+                jobs.append((ep_dir.name, cam, svo))
+
+    if jobs:
+        n_workers = workers or _default_workers()
+        print(
+            f"Scanning {len(jobs)} view(s) across {len(ep_dirs)} episode(s) "
+            f"with {n_workers} workers..."
+        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as ex:
+            futs = {
+                ex.submit(_analyze_svo, svo): (ep_id, cam) for ep_id, cam, svo in jobs
+            }
+            for fut in concurrent.futures.as_completed(futs):
+                ep_id, cam = futs[fut]
+                try:
+                    raw[ep_id][cam] = fut.result()
+                except Exception as e:
+                    print(f"  {ep_id}/{cam}: scan failed ({e})")
+        for ep_id in {ep_id for ep_id, _, _ in jobs}:
+            if raw[ep_id]:
+                _save_episode_cache(ep_by_id[ep_id], raw[ep_id])
+
+    raw = {ep_id: views for ep_id, views in raw.items() if views}
+    expected_cams = sorted({cam for views in raw.values() for cam in views})
+
+    episodes: Dict[str, Dict] = {}
+    for ep_id, views in raw.items():
+        drops = _frame_drops(views)
+        missing = [cam for cam in expected_cams if cam not in views]
+        episodes[ep_id] = {
+            "views": views,
+            "drops": drops,
+            "missing": missing,
+            "verdict": _episode_verdict(views, drops, missing),
+        }
+
+    items = sorted(episodes.items())
+    _print_table(items)
+
+    counts = {
+        "clean": 0,
+        "borderline": 0,
+        "bad": 0,
+        "broken": 0,
+        "black": 0,
+        "missing": 0,
+    }
+    for ep in episodes.values():
+        counts[ep["verdict"]] = counts.get(ep["verdict"], 0) + 1
+    print(
+        f"\nSummary (per-episode, worst view): clean={counts['clean']}  "
+        f"borderline={counts['borderline']}  bad={counts['bad']}  "
+        f"broken={counts['broken']}  black={counts['black']}  "
+        f"missing={counts['missing']}  (scanned {len(episodes)})"
+    )
+
+    report = {
+        "task": task_dir.name,
+        "total_episodes": len(ep_dirs),
+        "scanned_episodes": len(episodes),
+        "expected_cameras": expected_cams,
+        "verdicts": counts,
+        "thresholds": {
+            "clean_shrink_max": CLEAN_SHRINK,
+            "borderline_shrink_max": BORDERLINE_SHRINK,
+            "bad_shrink_max": BAD_SHRINK,
+            "clean_max_dt_ms": CLEAN_MAX_DT_MS,
+            "borderline_max_dt_ms": BORDERLINE_MAX_DT_MS,
+            "bad_max_dt_ms": BAD_MAX_DT_MS,
+            "min_frames": MIN_FRAMES,
+            "frame_drop_ratio": FRAME_DROP_RATIO,
+            "black_mean_max": BLACK_MEAN_MAX,
+            "black_ratio": BLACK_RATIO,
+        },
+        "episodes": {
+            ep_id: {
+                "verdict": ep["verdict"],
+                "drops": sorted(ep["drops"]),
+                "missing": ep["missing"],
+                "views": {cam: asdict(r) for cam, r in ep["views"].items()},
+            }
+            for ep_id, ep in items
+        },
+    }
+    report_path = task_dir / TASK_REPORT_NAME
+    report_path.write_text(json.dumps(report, indent=2))
+    print(f"Report saved to: {report_path}")
+
+    return report
+
+
+def select_inspect_tasks(data_dir: str = "data/raw") -> List[str]:
+    """Use fzf to select one or more raw recording task directories (Tab to multi-select)."""
+    base = Path(data_dir)
+    if not base.exists():
+        print(f"No recordings found in {base}")
+        sys.exit(1)
+
+    task_dirs = sorted(
+        d
+        for d in base.iterdir()
+        if d.is_dir()
+        and any(_is_episode_dir(sub) for sub in d.iterdir() if sub.is_dir())
+    )
+
+    if not task_dirs:
+        print(f"No tasks with cameras/*.svo2 recordings found in {base}")
+        sys.exit(1)
+
+    labels = {
+        f"{d.name}  ({sum(1 for s in d.iterdir() if _is_episode_dir(s))} recording(s))": d
+        for d in task_dirs
+    }
+
+    from raiden.utils import fzf_select
+
+    selected = fzf_select(list(labels), prompt="Inspect task(s)> ", multi=True)
+    if not selected:
+        return []
+    if isinstance(selected, str):
+        selected = [selected]
+    return [str(labels[s]) for s in selected]
+
+
+def run_inspect(
+    recording_dir: Optional[str] = None,
+    data_dir: str = "data",
+    force: bool = False,
+    workers: Optional[int] = None,
+) -> None:
+    """Entry point for ``rd inspect``.
+
+    With ``recording_dir`` set, inspect exactly that task directory; otherwise
+    open an fzf selector over ``<data_dir>/raw`` (Tab to multi-select tasks).
+    """
+    if recording_dir is not None:
+        inspect_task(Path(recording_dir), force=force, workers=workers)
+        return
+    for task_dir in select_inspect_tasks(str(Path(data_dir) / "raw")):
+        inspect_task(Path(task_dir), force=force, workers=workers)
+        print()

--- a/raiden/recorder.py
+++ b/raiden/recorder.py
@@ -380,6 +380,268 @@ class DemonstrationRecorder:
 
 
 # ---------------------------------------------------------------------------
+# DaggerRecorder — HG-DAgger rollout recording on shared, live camera handles
+# ---------------------------------------------------------------------------
+
+# Joints per follower arm (6 revolute + 1 gripper) in the 14-D command vector.
+_DAGGER_DOF = 7
+
+
+class DaggerRecorder:
+    """Record an HG-DAgger rollout in the exact ``rd record`` on-disk layout.
+
+    Unlike :class:`DemonstrationRecorder`, this does NOT own cameras, a grab
+    loop, or CAN — the running :class:`~raiden.inference.RaidenInferenceLoop`
+    owns all of that.  It simply:
+
+    1. Toggles SVO2 recording on the inference loop's *already-open* live ZED
+       handles (``server._cam_handles`` — raw ``sl.Camera`` objects, NOT the
+       :class:`raiden.cameras.Camera` wrappers ``DemonstrationRecorder`` uses).
+       Every existing inference ``grab()`` then also writes an SVO2 frame, so no
+       second ZED process is spawned.  The loop must quiesce its grab threads
+       (``server._grab_paused``) around ``start()``/``stop()`` to avoid the ZED
+       ``grab()`` vs ``(en|dis)able_recording`` deadlock.
+    2. Buffers per-step observations + the commanded 14-D joints + a
+       ``control_source`` flag (0 = policy, 1 = human takeover), then writes
+       ``robot_data.npz`` + ``metadata.json`` so ``rd convert`` → ``rd shardify``
+       ingest it unchanged.
+
+    Output layout (identical to ``rd record``)::
+
+        <recording_dir>/
+            cameras/<name>.svo2
+            robot_data.npz        # standard keys + control_source (N,) int8
+            metadata.json         # episode_kind='dagger', intervention_ratio
+
+    ``robot_data.npz`` includes ``follower_{l,r}_joint_cmd`` (built from the
+    loop's commanded actions) because the TRI converter *requires* commanded
+    poses to build action labels — unlike the YAM converter it will not fall
+    back to observed positions.
+    """
+
+    def __init__(
+        self,
+        cam_handles: Dict[str, dict],
+        robot_controller: RobotController,
+        recording_dir: Path,
+        task_name: str,
+        task_instruction: str,
+        camera_fps: int = 30,
+    ):
+        self.cam_handles = cam_handles
+        self.robot_controller = robot_controller
+        self.recording_dir = recording_dir
+        self.task_name = task_name
+        self.task_instruction = task_instruction
+        self.camera_fps = camera_fps
+
+        self.cameras_dir = recording_dir / "cameras"
+        self.cameras_dir.mkdir(parents=True, exist_ok=True)
+
+        self.is_recording = False
+        self._frames: List[Dict] = []
+        self._start_time: float = 0.0
+
+    def start(self) -> None:
+        """Enable SVO2 recording on each live ZED handle and begin buffering."""
+        if self.is_recording:
+            return
+        import pyzed.sl as sl
+
+        # DaggerRecorder can only record ZED handles (raw sl.Camera + SVO2). Warn
+        # loudly if any configured camera is skipped so the resulting dagger
+        # episode's smaller camera set is not a silent divergence from teleop
+        # recordings (a data-quality trap this toolkit exists to prevent).
+        skipped = [n for n, h in self.cam_handles.items() if h.get("type") != "zed"]
+        if skipped:
+            print(
+                f"  Warning: DaggerRecorder records ZED cameras only — NOT "
+                f"recording {skipped}. Dagger episodes will have fewer cameras "
+                f"than `rd record` teleop episodes for this task."
+            )
+
+        for name, handle in self.cam_handles.items():
+            # Only ZED handles carry a raw sl.Camera we can record from; a
+            # RealSense handle has a 'pipeline' but no 'camera' and is skipped.
+            if handle.get("type") != "zed":
+                continue
+            cam = handle.get("camera")
+            if cam is None:
+                continue
+            params = sl.RecordingParameters()
+            # Match raiden.cameras.zed.ZedCamera.start_recording so the SVO2
+            # files are identical to those produced by `rd record`.
+            params.compression_mode = sl.SVO_COMPRESSION_MODE.H264
+            params.video_filename = str(self.cameras_dir / f"{name}.svo2")
+            status = cam.enable_recording(params)
+            if status != sl.ERROR_CODE.SUCCESS:
+                print(f"  Warning: SVO2 recording failed for '{name}': {status}")
+
+        self._frames = []
+        self._start_time = time.monotonic()
+        self.is_recording = True
+
+    def add_frame(
+        self, t_ns: int, obs: Dict, control_source: int, joint_cmd: np.ndarray
+    ) -> None:
+        """Buffer one rollout frame (call once per inference control step).
+
+        Args:
+            t_ns: camera-SDK-clock timestamp (aligns with SVO2 frame timestamps).
+            obs: ``robot_controller.get_all_observations()`` snapshot.
+            control_source: 0 = policy drove this frame, 1 = human takeover.
+            joint_cmd: (14,) commanded joints ``[left(7), right(7)]`` (TRI order).
+        """
+        if not self.is_recording:
+            return
+        self._frames.append(
+            {
+                "t": int(t_ns),
+                "obs": obs,
+                "control_source": int(control_source),
+                "cmd": np.asarray(joint_cmd, dtype=np.float32),
+            }
+        )
+
+    def stop(self, complete: bool = True, verdict: Optional[str] = None) -> Path:
+        """Disable SVO2 recording and persist robot_data.npz + metadata.json."""
+        if not self.is_recording:
+            return self.recording_dir
+        self.is_recording = False
+        # Duration from the buffered frame timestamps (camera SDK clock), NOT
+        # wall clock: stop() runs AFTER the shutdown home move, so
+        # monotonic() - _start_time would over-count by the home-move seconds
+        # and understate robot_hz.  The frame span is the true data duration.
+        if len(self._frames) >= 2:
+            duration = (self._frames[-1]["t"] - self._frames[0]["t"]) / 1e9
+        else:
+            duration = time.monotonic() - self._start_time
+
+        for handle in self.cam_handles.values():
+            if handle.get("type") != "zed":
+                continue
+            cam = handle.get("camera")
+            if cam is not None:
+                try:
+                    cam.disable_recording()
+                except Exception:
+                    pass
+
+        self._save_robot_data()
+        self._save_metadata(duration, complete=complete, verdict=verdict)
+        return self.recording_dir
+
+    def discard(self) -> None:
+        """Disable SVO2 recording and delete the episode directory (no save)."""
+        self.is_recording = False
+        for handle in self.cam_handles.values():
+            if handle.get("type") != "zed":
+                continue
+            cam = handle.get("camera")
+            if cam is not None:
+                try:
+                    cam.disable_recording()
+                except Exception:
+                    pass
+        try:
+            shutil.rmtree(self.recording_dir)
+        except Exception as exc:
+            print(f"  (discard cleanup error: {exc})")
+
+    # ------------------------------------------------------------------
+
+    def _save_robot_data(self) -> None:
+        """Stack buffered frames into robot_data.npz (same keys as rd record)."""
+        output_file = self.recording_dir / "robot_data.npz"
+        n = len(self._frames)
+        if n == 0:
+            print("  Warning: no rollout frames recorded")
+            return
+
+        data: Dict[str, np.ndarray] = {}
+        data["timestamps"] = np.array([f["t"] for f in self._frames], dtype=np.int64)
+
+        # Stack every observation key for every robot (mirrors
+        # DemonstrationRecorder._save_robot_data).
+        robot_names = list(self._frames[0]["obs"].keys())
+        for robot_name in robot_names:
+            obs_keys = list(self._frames[0]["obs"][robot_name].keys())
+            for key in obs_keys:
+                arr = np.stack([f["obs"][robot_name][key] for f in self._frames])
+                data[f"{robot_name}_{key}"] = arr
+
+        # follower_<arm>_joint_pos_7d — observed: arm joints (6) + gripper (1).
+        for arm_key in ("follower_r", "follower_l"):
+            jp_key = f"{arm_key}_joint_pos"
+            gp_key = f"{arm_key}_gripper_pos"
+            if jp_key in data and gp_key in data:
+                grip = data[gp_key].reshape(n, 1).astype(np.float32)
+                data[f"{arm_key}_joint_pos_7d"] = np.concatenate(
+                    [data[jp_key].astype(np.float32), grip], axis=1
+                )
+
+        # follower_<arm>_joint_cmd — commanded: the 14-D action this loop sent
+        # ([left(7), right(7)], TRI order).  Required by the TRI converter.
+        cmds = np.stack([f["cmd"] for f in self._frames]).astype(np.float32)  # (N,14)
+        if "follower_l_joint_pos" in data:
+            data["follower_l_joint_cmd"] = cmds[:, :_DAGGER_DOF]
+        if "follower_r_joint_pos" in data:
+            data["follower_r_joint_cmd"] = cmds[:, _DAGGER_DOF : _DAGGER_DOF * 2]
+
+        # Per-frame HG-DAgger control_source flag (0 = policy, 1 = human).
+        data["control_source"] = np.array(
+            [f["control_source"] for f in self._frames], dtype=np.int8
+        )
+
+        np.savez_compressed(output_file, **data)
+        print(f"  ✓ Rollout data saved  ({n} frames) → {output_file}")
+
+    def _save_metadata(
+        self, duration: float, complete: bool = True, verdict: Optional[str] = None
+    ) -> None:
+        output_file = self.recording_dir / "metadata.json"
+        n = len(self._frames)
+        hz = n / duration if duration > 0 else 0.0
+        ratio = (
+            float(np.mean([f["control_source"] for f in self._frames])) if n else 0.0
+        )
+
+        # Only ZED handles actually wrote an SVO2 file; list just those so
+        # `rd convert` doesn't look for a video that was never recorded.
+        recorded_cameras = [
+            name
+            for name, handle in self.cam_handles.items()
+            if handle.get("type") == "zed" and handle.get("camera") is not None
+        ]
+        meta = RecordingMetadata(
+            task_name=self.task_name,
+            task_instruction=self.task_instruction,
+            timestamp=datetime.now().isoformat(),
+            duration_s=round(duration, 3),
+            robot_frames=n,
+            robot_hz=round(hz, 1),
+            cameras=recorded_cameras,
+            camera_fps=self.camera_fps,
+            control="dagger",
+            complete=complete,
+            converted=False,
+        )
+        # Extra keys beyond the RecordingMetadata dataclass (same pattern as
+        # DemonstrationRecorder's camera_start_times_ns).  Keeping them out of
+        # the dataclass leaves DemonstrationRecorder's metadata.json unchanged.
+        # convert/shardify read episode_kind + intervention_ratio to weight the
+        # human corrections.
+        meta_dict = asdict(meta)
+        meta_dict["verdict"] = verdict
+        meta_dict["episode_kind"] = "dagger"
+        meta_dict["intervention_ratio"] = round(ratio, 4)
+
+        with open(output_file, "w") as f:
+            json.dump(meta_dict, f, indent=2)
+        print(f"  ✓ Metadata saved → {output_file}  (intervention_ratio={ratio:.2f})")
+
+
+# ---------------------------------------------------------------------------
 # Camera factory
 # ---------------------------------------------------------------------------
 
@@ -508,7 +770,10 @@ def _next_recording_dir(task_dir: Path) -> Path:
     treated as an incomplete recording, wiped, and reused.  Otherwise a new
     numbered directory is created.
     """
-    existing = sorted(d for d in task_dir.iterdir() if d.is_dir() and d.name.isdigit())
+    existing = sorted(
+        (d for d in task_dir.iterdir() if d.is_dir() and d.name.isdigit()),
+        key=lambda d: int(d.name),
+    )
 
     if existing:
         last_dir = existing[-1]
@@ -525,7 +790,12 @@ def _next_recording_dir(task_dir: Path) -> Path:
             last_dir.mkdir()
             return last_dir
 
-    episode_idx = f"{len(existing):04d}"
+    # Number the next episode AFTER the highest existing index (max+1), NOT
+    # len(existing): if any earlier numbered dir was deleted (e.g. an appended
+    # dagger round, or a discarded episode) the count-based name would collide
+    # with a surviving dir and mkdir() would raise (YAM commit 58a6259).
+    next_num = int(existing[-1].name) + 1 if existing else 0
+    episode_idx = f"{next_num:04d}"
     new_dir = task_dir / episode_idx
     new_dir.mkdir()
     return new_dir

--- a/raiden/robot/controller.py
+++ b/raiden/robot/controller.py
@@ -79,6 +79,16 @@ _GRIPPER_SAFETY_THRESHOLD = 6.0 / 71.0
 # Full stroke (71 mm) closes/opens in 1/_GRIPPER_SPEED seconds.
 _GRIPPER_SPEED = 1.0
 
+# Full-close snap for the HG-DAgger takeover path, in normalized [0,1] gripper
+# space (0 = closed, 1 = open).  The leader trigger's physical throw saturates a
+# few percent short of the passive encoder's hardcoded range, so a full squeeze
+# only drives the gripper command down to ~0.04 instead of 0.0 and the follower
+# never fully closes — it holds a visible gap and drops small parts.  Snap a
+# nearly-bottomed trigger to a complete close so a takeover can command a full
+# grasp.  Applied only in _grip_clutch (the takeover path), NOT in the shared
+# leader read, so `rd teleop` / `rd record` behaviour is unchanged.
+_GRIP_FULL_CLOSE_SNAP = 0.05
+
 # ---------------------------------------------------------------------------
 # Pyroki / J-PARSE IK helpers
 # ---------------------------------------------------------------------------
@@ -271,13 +281,19 @@ def _grip_clutch(
     be shadowed onto the follower during policy mode — at takeover it sits
     wherever the operator's hand left it, uncorrelated with the policy's gripper.
     A relative/delta map then saturates: with the trigger parked at an end of its
-    travel the operator loses authority in one direction (e.g. trigger=0, grip=1
-    → can't open).  Instead HOLD the policy's gripper (``f0_grip``) until the
-    passive trigger crosses it, then track the trigger ABSOLUTELY (full 0–1
-    range) from there: no snap at takeover, never moves the gripper in an
-    unintended direction, and ``engaged`` latches True so a later trigger
-    reversal stays in absolute control.  Returns ``(cmd, engaged)``.
+    travel the operator loses authority in one direction (e.g. trigger parked at
+    0 with grip=1 → can never close).  Instead HOLD the policy's gripper
+    (``f0_grip``) until the passive trigger crosses it, then track the trigger
+    ABSOLUTELY (full 0–1 range) from there: no jump at takeover, never moves the
+    gripper in an unintended direction, and ``engaged`` latches True so a later
+    trigger reversal stays in absolute control.  Returns ``(cmd, engaged)``.
+
+    All values are in normalized gripper space: **0 = closed, 1 = open**.
     """
+    # Recover the last few percent of squeeze the trigger cannot physically
+    # reach, so a takeover can still command a full grasp.
+    if trigger <= _GRIP_FULL_CLOSE_SNAP:
+        trigger = 0.0
     if not engaged and (
         np.sign(l0_grip - f0_grip) == 0
         or np.sign(trigger - f0_grip) != np.sign(l0_grip - f0_grip)

--- a/raiden/robot/controller.py
+++ b/raiden/robot/controller.py
@@ -208,6 +208,22 @@ class YAMLeaderRobot:
         """Update PD gains"""
         self._robot.update_kp_kd(kp, kd)
 
+    def zero_torque_mode(self) -> None:
+        """Make the leader truly passive (free to backdrive by hand).
+
+        Delegates to the i2rt ``MotorChainRobot.zero_torque_mode()``, which
+        writes the *command* path (``_commands.kp/kd = 0``) — not just the
+        ``_kp/_kd`` gains that ``update_kp_kd`` mutates.  This matters: after a
+        home move the leader's non-zero gains are latched into the command path,
+        and the HG-DAgger loop never re-commands the leader, so a bare
+        ``update_kp_kd(0, 0)`` would never reach the motors and the leader would
+        stay PD-held at its last target (feels locked).  ``zero_torque_mode``
+        genuinely relaxes it.  Re-arm afterwards with ``update_kp_kd`` followed
+        by a ``command_joint_pos`` (which re-stamps the gains into the command
+        path).
+        """
+        self._robot.zero_torque_mode()
+
 
 def smooth_move_joints(
     robot: Robot,
@@ -239,6 +255,114 @@ def smooth_move_joints(
         robot.command_joint_pos(target_pos)
         if i < steps:
             time.sleep(time_interval_s / steps)
+
+
+# ---------------------------------------------------------------------------
+# HG-DAgger joint-delta takeover (pure numpy, no hardware coupling)
+# ---------------------------------------------------------------------------
+
+
+def _grip_clutch(
+    trigger: float, f0_grip: float, l0_grip: float, engaged: bool
+) -> Tuple[float, bool]:
+    """Bumpless absolute gripper for the unmotorized takeover trigger.
+
+    The leader gripper trigger has no motor, so unlike the 6 arm joints it can't
+    be shadowed onto the follower during policy mode — at takeover it sits
+    wherever the operator's hand left it, uncorrelated with the policy's gripper.
+    A relative/delta map then saturates: with the trigger parked at an end of its
+    travel the operator loses authority in one direction (e.g. trigger=0, grip=1
+    → can't open).  Instead HOLD the policy's gripper (``f0_grip``) until the
+    passive trigger crosses it, then track the trigger ABSOLUTELY (full 0–1
+    range) from there: no snap at takeover, never moves the gripper in an
+    unintended direction, and ``engaged`` latches True so a later trigger
+    reversal stays in absolute control.  Returns ``(cmd, engaged)``.
+    """
+    if not engaged and (
+        np.sign(l0_grip - f0_grip) == 0
+        or np.sign(trigger - f0_grip) != np.sign(l0_grip - f0_grip)
+    ):
+        engaged = True
+    cmd = trigger if engaged else f0_grip
+    return float(np.clip(cmd, 0.0, 1.0)), engaged
+
+
+def joint_delta_takeover(
+    leader_now: Dict[str, Optional[np.ndarray]],
+    q0: Tuple[
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+        Optional[np.ndarray],
+    ],
+    dof: int = 7,
+    grip_engaged: Optional[Dict[str, bool]] = None,
+) -> np.ndarray:
+    """Joint-space delta takeover command (HG-DAgger).
+
+    The leader and follower are kinematically identical YAM arms, so an operator
+    grabbing the leader can drive the follower by the leader's motion relative to
+    the moment of takeover — no FK/IK needed::
+
+        action = follower_q0 + (leader_now - leader_q0)        # per arm
+
+    The caller syncs the leader to the follower at takeover and captures
+    ``leader_q0`` from the SAME snapshot used for the first ``leader_now``, so the
+    arm term reduces to absolute mirroring while staying seam-free by
+    construction (the edge delta is exactly zero).  The gripper uses a bumpless
+    clutch (:func:`_grip_clutch`) instead of a delta.
+
+    Arm ordering (TRI convention, LEFT-then-RIGHT — differs from the YAM source
+    which packed RIGHT-then-LEFT).  This keeps the returned command consistent
+    with ``_ee_pose_to_joint_cmd`` and ``_smooth_command`` on the TRI server, so
+    the inference loop can command ``action[:dof]`` → left follower and
+    ``action[dof:]`` → right follower for BOTH teleop and policy actions:
+
+    Args:
+        leader_now: ``{"q7_l": (7,) | None, "q7_r": (7,) | None}`` — current
+            leader poses (6 joints + gripper), as read by the input thread.
+        q0: ``(follower_q0_l, follower_q0_r, leader_q0_l, leader_q0_r)`` — the
+            measured follower poses and leader poses snapshotted at the takeover
+            edge.  Each is ``(7,)`` or ``None`` (arm absent).
+        dof: joints per arm (default 7 = 6 revolute + 1 gripper).
+        grip_engaged: ``{"l": bool, "r": bool}`` clutch latch, owned + reset by
+            the caller at each takeover edge (see :func:`_grip_clutch`).  ``None``
+            allocates a transient, non-latching dict.
+
+    Returns:
+        ``(2*dof,)`` float32 command ``[left(7), right(7)]``.  On the takeover
+        edge (``leader_now == leader_q0``) this equals ``follower_q0`` exactly
+        (zero delta — no seam jump), and the gripper holds the takeover grip.  An
+        un-grabbed arm (no leader read) also holds its grip at ``follower_q0``.
+    """
+    f0_l, f0_r, l0_l, l0_r = q0
+    if grip_engaged is None:  # caller normally owns + persists this across the takeover
+        grip_engaged = {"l": False, "r": False}
+    action = np.zeros(dof * 2, dtype=np.float32)
+
+    ll = leader_now.get("q7_l")
+    if ll is not None and f0_l is not None and l0_l is not None:
+        ll = np.asarray(ll, dtype=np.float64)
+        l0_l = np.asarray(l0_l, dtype=np.float64)
+        action[:6] = f0_l[:6] + (ll[:6] - l0_l[:6])
+        action[6], grip_engaged["l"] = _grip_clutch(
+            ll[6], float(f0_l[6]), float(l0_l[6]), grip_engaged["l"]
+        )
+    elif f0_l is not None:
+        action[:dof] = f0_l
+
+    lr = leader_now.get("q7_r")
+    if lr is not None and f0_r is not None and l0_r is not None:
+        lr = np.asarray(lr, dtype=np.float64)
+        l0_r = np.asarray(l0_r, dtype=np.float64)
+        action[dof : dof + 6] = f0_r[:6] + (lr[:6] - l0_r[:6])
+        action[dof + 6], grip_engaged["r"] = _grip_clutch(
+            lr[6], float(f0_r[6]), float(l0_r[6]), grip_engaged["r"]
+        )
+    elif f0_r is not None:
+        action[dof : dof * 2] = f0_r
+
+    return action
 
 
 def list_can_interfaces() -> list[str]:
@@ -1398,6 +1522,127 @@ class RobotController:
             self.leader_r.update_kp_kd(kp=np.zeros(6), kd=np.zeros(6))
         if self.leader_l:
             self.leader_l.update_kp_kd(kp=np.zeros(6), kd=np.zeros(6))
+
+    def return_to_home_and_disconnect(self, threshold_rad: float = 0.03) -> None:
+        """Move arms toward home, close CAN once all joints are within *threshold_rad*.
+
+        Used by the HG-DAgger looped collector between episodes: it homes every
+        arm and closes ALL four CAN buses BEFORE the heavy recording finalize
+        (SVO2 flush + np.savez).  Closing CAN first means there are no motor
+        threads left for the GIL-hogging save to starve past the DM watchdog —
+        the same reason ``DemonstrationRecorder`` shuts robots down before
+        writing.
+
+        CAN errors tend to occur in the final timesteps of reaching the exact
+        home position, so by monitoring the *actual* joint positions and closing
+        the bus as soon as they are close enough, those final-timestep errors are
+        avoided.  After this call all CAN connections are closed.  Rebuild with
+        ``initialize_robots()`` for the next episode.
+        """
+        print("\nStopping teleoperation...")
+        self.stop_teleoperation()
+
+        print("Moving arms toward home...")
+        # Restore PD gains first: leaders may be in zero_torque_mode (passive
+        # for takeover) and would sag if commanded home with zero gains.
+        self.disable_gravity_compensation()
+
+        # Start home movement on all arms, with a shared stop signal.
+        stop_event = threading.Event()
+        time.sleep(1.0)
+
+        threads = []
+        if self.follower_r and self.follower_r.motor_chain.running:
+            threads.append(
+                threading.Thread(
+                    target=smooth_move_joints,
+                    args=(self.follower_r, FOLLOWER_HOME_POS),
+                    kwargs={
+                        "time_interval_s": 2.5,
+                        "steps": 125,
+                        "stop_event": stop_event,
+                    },
+                )
+            )
+        if self.follower_l and self.follower_l.motor_chain.running:
+            threads.append(
+                threading.Thread(
+                    target=smooth_move_joints,
+                    args=(self.follower_l, FOLLOWER_HOME_POS),
+                    kwargs={
+                        "time_interval_s": 2.5,
+                        "steps": 125,
+                        "stop_event": stop_event,
+                    },
+                )
+            )
+        if self.leader_r and self.leader_r._robot.motor_chain.running:
+            threads.append(
+                threading.Thread(
+                    target=smooth_move_joints,
+                    args=(self.leader_r._robot, LEADER_HOME_POS),
+                    kwargs={
+                        "time_interval_s": 2.5,
+                        "steps": 125,
+                        "stop_event": stop_event,
+                    },
+                )
+            )
+        if self.leader_l and self.leader_l._robot.motor_chain.running:
+            threads.append(
+                threading.Thread(
+                    target=smooth_move_joints,
+                    args=(self.leader_l._robot, LEADER_HOME_POS),
+                    kwargs={
+                        "time_interval_s": 2.5,
+                        "steps": 125,
+                        "stop_event": stop_event,
+                    },
+                )
+            )
+
+        for t in threads:
+            t.start()
+
+        # Monitor actual joint positions — signal stop once close enough.
+        while any(t.is_alive() for t in threads):
+            if self._all_joints_near_home(threshold_rad):
+                stop_event.set()
+                break
+            time.sleep(0.05)
+
+        for t in threads:
+            t.join(timeout=2.0)
+
+        # Shut down CAN — motors hold last position via internal state.
+        self.close()
+        print("✓ Arms near home — CAN disconnected, safe to unplug.")
+
+    def _all_joints_near_home(self, threshold_rad: float) -> bool:
+        """Return True if every active robot's joints are within *threshold_rad* of home.
+
+        Arms with dead CAN are skipped (already in hardware damping mode).
+        """
+        try:
+            if self.follower_r and self.follower_r.motor_chain.running:
+                pos = self.follower_r.get_joint_pos()
+                if not np.allclose(pos, FOLLOWER_HOME_POS, atol=threshold_rad):
+                    return False
+            if self.follower_l and self.follower_l.motor_chain.running:
+                pos = self.follower_l.get_joint_pos()
+                if not np.allclose(pos, FOLLOWER_HOME_POS, atol=threshold_rad):
+                    return False
+            if self.leader_r and self.leader_r._robot.motor_chain.running:
+                pos = self.leader_r.get_joint_pos()
+                if not np.allclose(pos, LEADER_HOME_POS, atol=threshold_rad):
+                    return False
+            if self.leader_l and self.leader_l._robot.motor_chain.running:
+                pos = self.leader_l.get_joint_pos()
+                if not np.allclose(pos, LEADER_HOME_POS, atol=threshold_rad):
+                    return False
+        except Exception:
+            return False  # CAN already dead — treat as "close enough"
+        return True
 
     def shutdown(self):
         """Complete shutdown: stop teleop -> restore control -> go home -> close robots"""

--- a/raiden/server.py
+++ b/raiden/server.py
@@ -338,10 +338,14 @@ class RaidenPolicyServer(chiral.PolicyServer):
             name: 0 for name in self._cam_handles
         }
 
-        # Initialize follower robots only (leaders not needed for inference).
+        # Follower arms are always initialized.  Leader arms are brought up only
+        # when a subclass asks for them: the base server (rd serve) leaves them
+        # off, while RaidenInferenceLoop overrides _wants_leaders() to True for
+        # the HG-DAgger interactive-correction loop.
+        _use_leaders = self._wants_leaders()
         self._robot = RobotController(
-            use_right_leader=False,
-            use_left_leader=False,
+            use_right_leader=_use_leaders,
+            use_left_leader=_use_leaders,
             use_right_follower=True,
             use_left_follower=True,
         )
@@ -365,6 +369,12 @@ class RaidenPolicyServer(chiral.PolicyServer):
         self._step_count = 0
         self._t_sum = 0.0
         self._running = True
+        # When set, the ZED capture loops skip grab() so a subclass can toggle
+        # SVO2 (enable/disable_recording) on the live camera handles without
+        # deadlocking the SDK (grab() vs recording-toggle).  Cleared by default,
+        # so rd serve behavior is unchanged; only RaidenInferenceLoop sets it
+        # (around DaggerRecorder start/stop in looped collection).
+        self._grab_paused = threading.Event()
         # Executor for async smooth commands so policy inference overlaps motion.
         self._smooth_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="smooth"
@@ -406,6 +416,20 @@ class RaidenPolicyServer(chiral.PolicyServer):
         self._robot.attach_footpedal(callback=self._trigger_estop)
 
         print("\nRaiden policy server ready.")
+
+    # -------------------------------------------------------------------------
+    # Extension hooks (overridden by RaidenInferenceLoop)
+    # -------------------------------------------------------------------------
+
+    def _wants_leaders(self) -> bool:
+        """Whether __init__ should bring up the leader arms.
+
+        The base policy server (rd serve) and plain inference use the followers
+        only, so this returns False.  RaidenInferenceLoop overrides it to return
+        True when running the HG-DAgger interactive-correction loop, which needs
+        the passive leaders for operator takeover.
+        """
+        return False
 
     # -------------------------------------------------------------------------
     # Calibration helpers
@@ -983,12 +1007,20 @@ class RaidenPolicyServer(chiral.PolicyServer):
     # Observation construction (overrides base class to add dynamic extrinsics)
     # -------------------------------------------------------------------------
 
-    def _make_obs(self) -> Observation:
+    def _make_obs(self, timestamp: Optional[float] = None) -> Observation:
         """Snapshot all buffers and compute per-step wrist camera extrinsics.
 
         All joint states are interpolated to the reference camera's latest frame
         arrival time so the observation is temporally coherent across cameras and
         the proprioception stream.
+
+        Args:
+            timestamp: If given, override the returned ``Observation.timestamp``
+                with this value (e.g. a synthetic step-based clock the inference
+                loop passes so the model sees monotonic step times).  Proprio /
+                camera interpolation still uses the ZED-clock reference time —
+                only the reported observation timestamp changes.  ``None``
+                (default) keeps the original behavior (reference ZED time).
         """
         # Reference timestamp: the reference camera's arrival time shifted onto
         # the unified time axis (arrival_ts + phase_offset).
@@ -1072,7 +1104,9 @@ class RaidenPolicyServer(chiral.PolicyServer):
             ].astype(np.float32)
 
         return Observation(
-            cameras=cameras, proprios=proprios, timestamp=ref_ts_ns * 1e-9
+            cameras=cameras,
+            proprios=proprios,
+            timestamp=(timestamp if timestamp is not None else ref_ts_ns * 1e-9),
         )
 
     def _read_proprio(self, name: str) -> Optional[np.ndarray]:
@@ -1252,6 +1286,14 @@ class RaidenPolicyServer(chiral.PolicyServer):
             confidence_threshold=99, texture_confidence_threshold=100
         )
         while self._running:
+            # HG-DAgger: a DaggerRecorder toggles SVO2 recording
+            # (enable/disable_recording) on this same live handle between
+            # episodes.  A concurrent grab() during that toggle deadlocks the
+            # ZED SDK, so quiesce grabbing while _grab_paused is set.  Default
+            # clear → no behavior change for rd serve.
+            if self._grab_paused.is_set():
+                time.sleep(0.02)
+                continue
             if cam.grab(runtime) == sl.ERROR_CODE.SUCCESS:
                 # Record hardware capture timestamp immediately after grab, before
                 # any processing, so it matches the ZED clock used in the recorder.

--- a/raiden/shardify.py
+++ b/raiden/shardify.py
@@ -90,6 +90,18 @@ class ShardifyConfig:
     #: Only feed every N-th sample into the stats accumulators to save memory.
     stats_stride: int = 10
 
+    # Recovery-data (HG-DAgger) subsetting
+    #: Which anchor frames to keep, by per-frame ``control_source``:
+    #: ``"all"`` (every frame), ``"interventions"`` (only human-takeover frames,
+    #: ``control_source == 1``), or ``"interventions_context"`` (interventions
+    #: plus the ``keep_context`` policy frames leading into each one — the drift
+    #: window). ``"all"`` is the ABC-preferred recipe (keep diversity, upweight
+    #: corrections via ``sample_weight``).
+    keep: str = "all"
+    #: Number of leading policy frames to retain before each intervention when
+    #: ``keep == "interventions_context"``.
+    keep_context: int = 15
+
 
 # ---------------------------------------------------------------------------
 # Rotation helpers
@@ -745,6 +757,34 @@ def select_processed_task(data_dir: str = "data") -> List[Tuple[Path, List[Path]
 # ---------------------------------------------------------------------------
 
 
+def _keep_anchor(
+    control_source: np.ndarray,
+    t: int,
+    keep: str,
+    keep_context: int,
+    n_frames: int,
+) -> bool:
+    """Decide whether anchor frame ``t`` survives the ``--keep`` filter.
+
+    - ``"all"``: always keep.
+    - ``"interventions"``: keep only human-takeover frames (``control_source==1``).
+    - ``"interventions_context"``: keep interventions plus the ``keep_context``
+      policy frames leading into each one. Implemented as a forward look-ahead —
+      frame ``t`` is kept iff an intervention begins within the next
+      ``keep_context`` frames, which is exactly the drift window before it.
+      ``max(1, keep_context)`` means ``keep_context == 0`` still keeps the single
+      frame immediately before an intervention (not "interventions only").
+    """
+    if keep == "all":
+        return True
+    if control_source[t] == 1:
+        return True
+    if keep == "interventions_context":
+        hi = min(n_frames, t + max(1, keep_context) + 1)
+        return bool((control_source[t:hi] == 1).any())
+    return False  # keep == "interventions" and this is a policy frame
+
+
 def _build_sample(
     args: tuple,
 ) -> Dict[str, Any]:
@@ -770,6 +810,17 @@ def _build_sample(
     control = ctx["control"]
     ep_dir = ctx["ep_dir"]
     s = config.stride
+
+    # ── keep filter (HG-DAgger recovery-data subsetting) ──────────────
+    # Runs first, before any window/image work, so dropped anchors are cheap.
+    # NOTE: on data without control_source (ordinary teleop, or converts made
+    # before this feature) the array is all-zero, so keep != "all" yields ZERO
+    # samples — the filter empties the set rather than no-opping. Use keep=all
+    # (the default) on non-dagger data.
+    if not _keep_anchor(
+        ctx["control_source"], t, config.keep, config.keep_context, n_frames
+    ):
+        return {"filtered": "keep"}
 
     # ── padding filter ────────────────────────────────────────────────
     left_frames_needed = config.past_lowdim_steps * s
@@ -853,6 +904,15 @@ def _build_sample(
         "original_episode_length": n_frames,
         "is_padded": left_pad > 0 or right_pad > 0,
         "control": control,
+        # Recovery-data provenance, so a merged shard set stays splittable for
+        # the ABC 80:10:10 base/intervention mix.
+        "episode_kind": ctx["episode_kind"],
+        "is_intervention": bool(
+            np.asarray(frames[t].get("is_intervention", False)).reshape(-1)[0]
+        ),
+        "sample_weight": float(
+            np.asarray(frames[t].get("sample_weight", 1.0)).reshape(-1)[0]
+        ),
     }
     sample_files[f"{sample_uuid}.metadata.json"] = json.dumps(sample_meta).encode()
 
@@ -933,6 +993,7 @@ def run_shardify(
     filtered_padding = 0
     filtered_still = 0
     filtered_nan = 0
+    filtered_keep = 0
     stats_counter = 0
 
     # ── Phase 1: load all episodes ────────────────────────────────────────
@@ -954,11 +1015,22 @@ def run_shardify(
         anchor_frame = frames[0]
         with open(ep_dir / "metadata.json") as _mf:
             _ep_meta = json.load(_mf)
+        # Per-frame human-takeover flag, read once so the keep filter and the
+        # interventions_context look-ahead are O(1) per anchor. Defaults to all
+        # zeros on ordinary (non-dagger) episodes.
+        control_source = np.array(
+            [
+                int(np.asarray(fr.get("control_source", 0)).reshape(-1)[0])
+                for fr in frames
+            ],
+            dtype=np.int8,
+        )
         ep_contexts.append(
             {
                 "ep_dir": ep_dir,
                 "frames": frames,
                 "n_frames": len(frames),
+                "control_source": control_source,
                 "src_cam_names": [
                     _reverse_map(config.camera_name_map, out_cam)
                     for out_cam in output_cam_names
@@ -967,6 +1039,7 @@ def run_shardify(
                 "language_prompt": str(anchor_frame.get("language_prompt", "")),
                 "episode_id": ep_dir.name,
                 "control": _ep_meta.get("control", "leader"),
+                "episode_kind": _ep_meta.get("episode_kind", "teleop"),
             }
         )
         total_frames += len(frames)
@@ -1003,6 +1076,8 @@ def run_shardify(
                 filtered_still += 1
             elif result["filtered"] == "nan":
                 filtered_nan += 1
+            elif result["filtered"] == "keep":
+                filtered_keep += 1
             else:
                 writer.add(result["sample_files"])
                 total_samples += 1
@@ -1010,7 +1085,10 @@ def run_shardify(
                 ep_sample_counts[episode_id] = ep_sample_counts.get(episode_id, 0) + 1
                 stats_counter += 1
                 pbar.set_postfix(
-                    filtered=filtered_padding + filtered_still + filtered_nan,
+                    filtered=filtered_padding
+                    + filtered_still
+                    + filtered_nan
+                    + filtered_keep,
                     shard=writer._shard_idx,
                 )
 
@@ -1078,6 +1156,8 @@ def run_shardify(
             "padding_samples_filtered": filtered_padding,
             "still_samples_filtered": filtered_still,
             "nan_samples_filtered": filtered_nan,
+            "keep_samples_filtered": filtered_keep,
+            "keep_mode": config.keep,
             "elapsed_seconds": round(elapsed, 1),
         },
     }
@@ -1086,10 +1166,11 @@ def run_shardify(
     with open(shard_dir / "processing_metadata.json", "w") as f:
         json.dump(proc_meta, f, indent=2)
 
+    keep_msg = f" keep[{config.keep}]={filtered_keep}" if config.keep != "all" else ""
     print(
         f"\nDone: {total_samples} samples → {writer._shard_idx} shards  "
-        f"filtered: {filtered_padding + filtered_still + filtered_nan} "
-        f"(pad={filtered_padding} still={filtered_still} nan={filtered_nan})  "
+        f"filtered: {filtered_padding + filtered_still + filtered_nan + filtered_keep} "
+        f"(pad={filtered_padding} still={filtered_still} nan={filtered_nan}{keep_msg})  "
         f"elapsed: {elapsed:.0f}s"
     )
     print(f"Output: {shard_dir}")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,153 @@
+"""Tests for ``raiden.robot.controller`` takeover control.
+
+Hardware-free: exercises the pure ``_grip_clutch`` / ``joint_delta_takeover``
+functions directly — no CAN bus, motors, or leader/follower arms required.
+
+Gripper values throughout are normalized gripper space: **0 = closed, 1 = open**
+(``Button 0 → close (0.0), Button 1 → open (1.0)``; the leader read computes
+``gripper_cmd = 1 - encoder_position``, so squeezing the trigger lowers it).
+
+Run with::
+
+    uv run pytest tests/test_controller.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from raiden.robot.controller import (
+    _GRIP_FULL_CLOSE_SNAP,
+    _grip_clutch,
+    joint_delta_takeover,
+)
+
+# ---------------------------------------------------------------------------
+# _grip_clutch — bumpless absolute gripper for the unmotorized takeover trigger
+# ---------------------------------------------------------------------------
+
+
+def test_clutch_can_fully_close_after_takeover():
+    """Policy left the gripper OPEN (1) while the passive trigger is parked
+    fully squeezed (0). A relative map could never close it (min reachable == 1).
+    The clutch holds open, engages once the trigger catches up, then closes."""
+    f0, l0 = 1.0, 0.0  # follower grip open, leader trigger squeezed at takeover
+    engaged = False
+
+    cmd, engaged = _grip_clutch(0.0, f0, l0, engaged)
+    assert cmd == 1.0 and engaged is False  # no jump at takeover
+
+    cmd, engaged = _grip_clutch(0.5, f0, l0, engaged)
+    assert cmd == 1.0 and engaged is False  # still catching up, still held
+
+    cmd, engaged = _grip_clutch(1.0, f0, l0, engaged)
+    assert engaged is True and cmd == 1.0  # trigger crossed grip -> engaged
+
+    cmd, engaged = _grip_clutch(0.0, f0, l0, engaged)
+    assert cmd == 0.0  # THE FIX: gripper can now fully close (was impossible)
+
+
+def test_clutch_immediate_when_trigger_matches_grip():
+    """If the trigger already sits at the follower grip at takeover, engage at
+    once and track absolutely — trivially bumpless."""
+    cmd, engaged = _grip_clutch(0.3, 0.3, 0.3, False)
+    assert engaged is True and abs(cmd - 0.3) < 1e-9
+
+
+def test_clutch_does_not_drop_object_at_takeover():
+    """Holding an object (grip=0, closed) with the trigger parked open must NOT
+    move the gripper in the unintended (opening) direction on takeover."""
+    cmd, engaged = _grip_clutch(0.8, 0.0, 0.8, False)
+    assert cmd == 0.0 and engaged is False
+
+
+def test_clutch_latches_through_reversal():
+    """Once engaged, reversing the trigger back across the grip value stays in
+    absolute control (must not re-hold the old grip)."""
+    engaged = False
+    for trigger in (0.0, 0.5, 0.8):  # rise from below, cross grip=0.5, engage
+        cmd, engaged = _grip_clutch(trigger, 0.5, 0.0, engaged)
+    cmd, engaged = _grip_clutch(0.2, 0.5, 0.0, engaged)  # back below grip
+    assert engaged is True and abs(cmd - 0.2) < 1e-9
+
+
+def test_clutch_engage_from_above():
+    """Symmetric case: trigger starts ABOVE the grip at takeover."""
+    f0, l0 = 0.2, 1.0
+    cmd, engaged = _grip_clutch(1.0, f0, l0, False)
+    assert cmd == 0.2 and engaged is False  # holds at takeover
+    cmd, engaged = _grip_clutch(0.2, f0, l0, engaged)
+    assert engaged is True  # crossed -> engaged
+    cmd, engaged = _grip_clutch(0.0, f0, l0, engaged)
+    assert cmd == 0.0  # full close reachable
+
+
+def test_clutch_snaps_nearly_bottomed_trigger_to_full_close():
+    """The trigger's throw saturates a few percent short of a full squeeze, so
+    without a snap the follower never fully closes. A nearly-bottomed trigger
+    must command a complete close once engaged."""
+    residual = _GRIP_FULL_CLOSE_SNAP / 2.0  # e.g. 0.025 — inside the dead band
+    cmd, engaged = _grip_clutch(residual, residual, residual, False)
+    assert engaged is True and cmd == 0.0  # snapped to a full close
+
+    # Just outside the dead band the trigger is still tracked verbatim.
+    outside = _GRIP_FULL_CLOSE_SNAP * 2.0
+    cmd, _ = _grip_clutch(outside, outside, outside, False)
+    assert abs(cmd - outside) < 1e-9
+
+
+def test_clutch_snap_does_not_disturb_a_held_grip():
+    """While the clutch is still holding (not engaged), the snap must not leak
+    into the commanded value — the policy's grip is passed through untouched."""
+    # Trigger parked nearly bottomed (inside the snap band) and still BELOW the
+    # policy's grip, so the clutch has not engaged yet.
+    cmd, engaged = _grip_clutch(0.0, 0.6, 0.02, False)
+    assert engaged is False and abs(cmd - 0.6) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# joint_delta_takeover — arm seam-free + gripper clutch threaded end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_takeover_seam_free_edge_and_clutch():
+    """q0 is (f0_l, f0_r, l0_l, l0_r) and the action is LEFT-then-RIGHT, so the
+    right arm occupies action[7:14] and its gripper is action[13]."""
+    f0_r = np.array([0, 0, 0, 0, 0, 0, 1.0])  # follower: arm home, grip open
+    l0_r = np.array([0, 0, 0, 0, 0, 0, 0.0])  # leader at takeover: trigger squeezed
+    q0 = (None, f0_r, None, l0_r)
+    grip_engaged = {"l": False, "r": False}
+
+    # Takeover edge: leader_now == leader_q0 -> zero arm delta, grip held.
+    a = joint_delta_takeover(
+        {"q7_r": l0_r.copy()}, q0, dof=7, grip_engaged=grip_engaged
+    )
+    assert np.allclose(a[7:13], 0.0)
+    assert a[13] == 1.0 and grip_engaged["r"] is False
+
+    # Operator moves the arm +0.1 and releases the trigger fully (catch-up -> engage).
+    a = joint_delta_takeover(
+        {"q7_r": np.array([0.1, 0, 0, 0, 0, 0, 1.0])},
+        q0,
+        dof=7,
+        grip_engaged=grip_engaged,
+    )
+    assert abs(a[7] - 0.1) < 1e-9  # arm still tracks the leader delta
+    assert grip_engaged["r"] is True
+
+    # Squeezing the trigger now closes the gripper (the previously-stuck direction).
+    a = joint_delta_takeover(
+        {"q7_r": np.array([0.1, 0, 0, 0, 0, 0, 0.0])},
+        q0,
+        dof=7,
+        grip_engaged=grip_engaged,
+    )
+    assert a[13] == 0.0
+
+
+def test_takeover_ungrabbed_arm_holds_grip():
+    """An arm with no leader read holds its follower takeover pose (incl. grip)."""
+    f0_l = np.array([0, 0, 0, 0, 0, 0, 0.7])
+    q0 = (f0_l, None, None, None)
+    a = joint_delta_takeover({}, q0, dof=7, grip_engaged={"l": False, "r": False})
+    assert np.allclose(a[0:7], f0_l)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,118 @@
+"""Tests for ``raiden.converter`` recovery-tag resampling.
+
+``control_source`` is a discrete 0/1 human-takeover flag recorded on the robot
+clock and replayed onto the camera-frame grid. Interpolating it would smear it
+into a meaningless fraction, so it is resampled by NEAREST timestamp — these
+tests pin that behaviour down.
+
+Run with::
+
+    uv run pytest tests/test_converter.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from raiden.converter import _resample_flag_nearest
+
+MS = 1_000_000  # nanoseconds per millisecond
+
+
+def test_identity_when_grids_match():
+    robot_ts = np.arange(6, dtype=np.int64) * 10 * MS
+    flag = np.array([0, 0, 1, 1, 0, 0], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, robot_ts)
+    assert np.array_equal(out, flag)
+
+
+def test_output_is_always_a_clean_flag_never_interpolated():
+    """The whole point: sampling across a 0->1 edge must never yield a fraction.
+
+    ``np.interp`` on the same inputs produces intermediate values; nearest does
+    not.
+    """
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    ref_ts = np.linspace(0, 100 * MS, 11).astype(np.int64)
+
+    out = _resample_flag_nearest(flag, robot_ts, ref_ts)
+    assert set(np.unique(out)).issubset({0, 1})
+
+    smeared = np.interp(ref_ts, robot_ts, flag)
+    assert not set(np.unique(smeared)).issubset({0, 1})  # documents the contrast
+
+
+def test_picks_the_nearer_robot_sample():
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    # 40 ms is nearer the first sample, 60 ms nearer the second.
+    out = _resample_flag_nearest(
+        flag, robot_ts, np.array([40 * MS, 60 * MS], dtype=np.int64)
+    )
+    assert out.tolist() == [0, 1]
+
+
+def test_exact_tie_picks_the_earlier_sample():
+    """Ties resolve left (``<=``) so the result is deterministic."""
+    robot_ts = np.array([0, 100 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, np.array([50 * MS], dtype=np.int64))
+    assert out.tolist() == [0]
+
+
+def test_camera_frame_before_first_robot_sample_clamps_to_first():
+    robot_ts = np.array([100 * MS, 200 * MS], dtype=np.int64)
+    flag = np.array([1, 0], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, np.array([0], dtype=np.int64))
+    assert out.tolist() == [1]
+
+
+def test_camera_frame_after_last_robot_sample_clamps_to_last():
+    robot_ts = np.array([100 * MS, 200 * MS], dtype=np.int64)
+    flag = np.array([0, 1], dtype=np.int8)
+    out = _resample_flag_nearest(
+        flag, robot_ts, np.array([10_000 * MS], dtype=np.int64)
+    )
+    assert out.tolist() == [1]
+
+
+def test_downsampling_preserves_an_intervention_block():
+    """Robot logs at 100 Hz, cameras at 30 Hz. A takeover spanning robot frames
+    40-59 (400-600 ms) must still be marked on the camera grid."""
+    robot_ts = (np.arange(100) * 10 * MS).astype(np.int64)
+    flag = np.zeros(100, dtype=np.int8)
+    flag[40:60] = 1
+    ref_ts = (np.arange(30) * int(1e9 / 30)).astype(np.int64)
+
+    out = _resample_flag_nearest(flag, robot_ts, ref_ts)
+
+    assert set(np.unique(out)).issubset({0, 1})
+    marked = ref_ts[out == 1]
+    assert marked.min() >= 390 * MS and marked.max() <= 610 * MS
+    assert out.sum() > 0
+
+
+def test_all_policy_and_all_human_are_preserved():
+    robot_ts = (np.arange(10) * 10 * MS).astype(np.int64)
+    ref_ts = (np.arange(5) * 20 * MS).astype(np.int64)
+    zeros = _resample_flag_nearest(np.zeros(10, dtype=np.int8), robot_ts, ref_ts)
+    ones = _resample_flag_nearest(np.ones(10, dtype=np.int8), robot_ts, ref_ts)
+    assert zeros.tolist() == [0] * 5
+    assert ones.tolist() == [1] * 5
+
+
+def test_returns_int8_matching_the_reference_grid_length():
+    robot_ts = (np.arange(10) * 10 * MS).astype(np.int64)
+    ref_ts = (np.arange(7) * 13 * MS).astype(np.int64)
+    out = _resample_flag_nearest(np.ones(10), robot_ts, ref_ts)
+    assert out.dtype == np.int8
+    assert out.shape == (7,)
+
+
+def test_column_shaped_flag_is_flattened():
+    """``robot_data.npz`` may store the flag as (N, 1); it is reshaped to (N,)."""
+    robot_ts = (np.arange(4) * 10 * MS).astype(np.int64)
+    flag = np.array([[0], [1], [1], [0]], dtype=np.int8)
+    out = _resample_flag_nearest(flag, robot_ts, robot_ts)
+    assert out.tolist() == [0, 1, 1, 0]

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,0 +1,209 @@
+"""Tests for ``raiden.inspector`` verdict classification.
+
+Hardware-free: exercises the pure classification maths, so no ZED SDK and no
+SVO2 files are needed (``pyzed`` is imported lazily inside ``_scan_svo2``).
+
+Run with::
+
+    uv run pytest tests/test_inspector.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from raiden.inspector import (
+    BLACK_RATIO,
+    CLEAN_MAX_DT_MS,
+    CLEAN_SHRINK,
+    MIN_FRAMES,
+    VERDICT_RANK,
+    _classify,
+    _is_episode_dir,
+    _result_from_scan,
+)
+
+FRAME_NS = int(1e9 / 30)  # nominal 30 Hz capture period
+
+
+def _ts(n_frames: int, gaps_ms: dict[int, float] | None = None) -> np.ndarray:
+    """Timestamps for ``n_frames`` at a perfect 30 Hz.
+
+    ``gaps_ms`` adds extra delay (in ms) after the given frame index, simulating
+    a capture stutter.
+    """
+    dt = np.full(n_frames - 1, FRAME_NS, dtype=np.int64)
+    for idx, extra_ms in (gaps_ms or {}).items():
+        dt[idx] += int(extra_ms * 1e6)
+    return np.concatenate([[0], np.cumsum(dt)]).astype(np.int64)
+
+
+# ---------------------------------------------------------------------------
+# _classify — the shrink / max-dt / frame-count verdict ladder
+# ---------------------------------------------------------------------------
+
+
+def test_classify_nominal_recording_is_clean():
+    assert _classify(shrink=1.0, max_dt_ms=33.4, n_frames=1000) == "clean"
+
+
+def test_classify_thresholds_are_exclusive():
+    """Thresholds compare with a strict ``>``, so a value sitting exactly on the
+    boundary stays in the better bucket."""
+    assert _classify(CLEAN_SHRINK, 33.4, 1000) == "clean"
+    assert _classify(1.0, CLEAN_MAX_DT_MS, 1000) == "clean"
+
+
+@pytest.mark.parametrize(
+    ("shrink", "expected"),
+    [(1.0, "clean"), (1.06, "borderline"), (1.11, "bad"), (1.21, "broken")],
+)
+def test_classify_shrink_ladder(shrink, expected):
+    assert _classify(shrink, 33.4, 1000) == expected
+
+
+@pytest.mark.parametrize(
+    ("max_dt_ms", "expected"),
+    [(33.4, "clean"), (201.0, "borderline"), (1001.0, "bad"), (2001.0, "broken")],
+)
+def test_classify_max_dt_ladder(max_dt_ms, expected):
+    assert _classify(1.0, max_dt_ms, 1000) == expected
+
+
+def test_classify_too_few_frames_is_broken():
+    """A near-empty recording is broken however good its timing looks."""
+    assert _classify(1.0, 33.4, MIN_FRAMES - 1) == "broken"
+    assert _classify(1.0, 33.4, MIN_FRAMES) == "clean"
+
+
+def test_classify_worst_axis_wins():
+    """Timing and frame-drop are orthogonal; the worse of the two decides."""
+    assert _classify(shrink=1.0, max_dt_ms=1500.0, n_frames=1000) == "bad"
+    assert _classify(shrink=1.15, max_dt_ms=33.4, n_frames=1000) == "bad"
+
+
+def test_verdict_rank_orders_worst_last():
+    ranked = sorted(VERDICT_RANK, key=lambda v: VERDICT_RANK[v])
+    assert ranked == ["clean", "borderline", "bad", "broken", "black", "missing"]
+
+
+# ---------------------------------------------------------------------------
+# _result_from_scan — raw scan -> classified InspectResult
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_frames", [0, 1])
+def test_result_degenerate_scan_is_broken(n_frames):
+    """Fewer than two timestamps means no interval to measure — broken, and the
+    metrics are zeroed rather than left undefined."""
+    res = _result_from_scan(
+        _ts(2)[:n_frames], sdk_total=10, n_errors=0, n_black=0, svo_mtime_ns=7
+    )
+    assert res.verdict == "broken"
+    assert res.n_frames == n_frames
+    assert res.shrink == 0.0
+    assert res.max_dt_ms == 0.0
+    assert res.svo2_mtime_ns == 7
+
+
+def test_result_nominal_scan_is_clean():
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0
+    )
+    assert res.verdict == "clean"
+    assert res.n_frames == 1000
+    assert res.shrink == pytest.approx(1.0, abs=1e-3)
+    assert res.max_dt_ms == pytest.approx(1000 / 30, abs=1e-3)
+    assert res.gaps_over_50ms == 0
+
+
+def test_result_stutter_degrades_the_verdict_and_counts_gaps():
+    """One long stall shows up in max_dt, the gap counters, and the verdict."""
+    res = _result_from_scan(
+        _ts(1000, {500: 600.0}), sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0
+    )
+    assert res.verdict == "borderline"
+    assert res.max_dt_ms == pytest.approx(1000 / 30 + 600.0, abs=1e-3)
+    assert res.gaps_over_500ms == 1
+    assert res.gaps_over_50ms == 1
+
+
+def test_result_dropped_frames_show_up_as_shrink():
+    """Half the frames lost over the same wall-clock span doubles shrink, so the
+    surviving frames would replay at 2x speed."""
+    ts = _ts(1000)[::2]  # keep every other frame: same span, half the frames
+    res = _result_from_scan(ts, sdk_total=1000, n_errors=0, n_black=0, svo_mtime_ns=0)
+    assert res.shrink == pytest.approx(2.0, abs=1e-2)
+    assert res.verdict == "broken"
+
+
+def test_result_black_left_eye_overrides_timing():
+    """A dead left eye corrupts the training RGB outright, so it beats an
+    otherwise-clean timing verdict."""
+    n_black = int(1000 * BLACK_RATIO) + 1
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1000, n_errors=0, n_black=n_black, svo_mtime_ns=0
+    )
+    assert res.verdict == "black"
+    assert res.black_ratio == pytest.approx(n_black / 1000)
+
+
+def test_result_black_ratio_threshold_is_exclusive():
+    """Exactly at BLACK_RATIO is not black — the check is a strict ``>``."""
+    res = _result_from_scan(
+        _ts(1000),
+        sdk_total=1000,
+        n_errors=0,
+        n_black=int(1000 * BLACK_RATIO),
+        svo_mtime_ns=0,
+    )
+    assert res.verdict == "clean"
+
+
+def test_result_preserves_timing_metrics_under_a_black_verdict():
+    """The timing numbers stay available for diagnosis even when black wins."""
+    res = _result_from_scan(
+        _ts(1000, {500: 600.0}), sdk_total=1000, n_errors=0, n_black=500, svo_mtime_ns=0
+    )
+    assert res.verdict == "black"
+    assert res.gaps_over_500ms == 1
+
+
+def test_result_reports_grab_errors_verbatim():
+    res = _result_from_scan(
+        _ts(1000), sdk_total=1010, n_errors=10, n_black=0, svo_mtime_ns=0
+    )
+    assert res.n_grab_errors == 10
+    assert res.sdk_total_frames == 1010
+
+
+# ---------------------------------------------------------------------------
+# _is_episode_dir — what counts as an episode on disk
+# ---------------------------------------------------------------------------
+
+
+def test_is_episode_dir_requires_cameras_with_svo2(tmp_path):
+    ep = tmp_path / "0000"
+    (ep / "cameras").mkdir(parents=True)
+    (ep / "cameras" / "scene_camera.svo2").touch()
+    assert _is_episode_dir(ep) is True
+
+
+def test_is_episode_dir_rejects_empty_cameras_dir(tmp_path):
+    ep = tmp_path / "0000"
+    (ep / "cameras").mkdir(parents=True)
+    assert _is_episode_dir(ep) is False
+
+
+def test_is_episode_dir_rejects_dir_without_cameras(tmp_path):
+    ep = tmp_path / "0000"
+    ep.mkdir()
+    (ep / "robot_data.npz").touch()
+    assert _is_episode_dir(ep) is False
+
+
+def test_is_episode_dir_rejects_a_file(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.touch()
+    assert _is_episode_dir(f) is False

--- a/tests/test_shardify.py
+++ b/tests/test_shardify.py
@@ -1,0 +1,104 @@
+"""Tests for ``raiden.shardify`` ``--keep`` subsetting.
+
+``_keep_anchor`` decides which anchor frames survive the keep filter, so a whole
+recorded rollout can be subset to the human corrections (and the drift window
+leading into them) at shard time rather than at record time.
+
+Run with::
+
+    uv run pytest tests/test_shardify.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from raiden.shardify import _keep_anchor
+
+
+def _keep_mask(control_source, keep, keep_context=15):
+    """Apply the filter across a whole episode, returning the kept indices."""
+    cs = np.asarray(control_source, dtype=np.int8)
+    n = len(cs)
+    return [t for t in range(n) if _keep_anchor(cs, t, keep, keep_context, n)]
+
+
+# ---------------------------------------------------------------------------
+# keep == "all" — the default, unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_all_keeps_every_frame():
+    cs = [0, 0, 1, 1, 0]
+    assert _keep_mask(cs, "all") == [0, 1, 2, 3, 4]
+
+
+def test_all_keeps_a_pure_teleop_episode():
+    """Ordinary demos have control_source all-zero and must be untouched."""
+    assert _keep_mask([0] * 6, "all") == list(range(6))
+
+
+# ---------------------------------------------------------------------------
+# keep == "interventions" — corrections only
+# ---------------------------------------------------------------------------
+
+
+def test_interventions_keeps_only_human_frames():
+    cs = [0, 0, 1, 1, 0, 1]
+    assert _keep_mask(cs, "interventions") == [2, 3, 5]
+
+
+def test_interventions_on_a_teleop_episode_keeps_nothing():
+    """The documented footgun: control_source is 0 for every ordinary teleop
+    frame, so this mode empties a non-dagger dataset."""
+    assert _keep_mask([0] * 10, "interventions") == []
+
+
+def test_interventions_ignores_keep_context():
+    """Lead-in frames belong to interventions_context only."""
+    cs = [0, 0, 0, 1]
+    assert _keep_mask(cs, "interventions", keep_context=2) == [3]
+
+
+# ---------------------------------------------------------------------------
+# keep == "interventions_context" — corrections plus the drift window
+# ---------------------------------------------------------------------------
+
+
+def test_context_keeps_the_lead_in_frames():
+    """With keep_context=2, the two policy frames before the takeover survive
+    and the earlier drift does not."""
+    cs = [0, 0, 0, 1, 0]
+    assert _keep_mask(cs, "interventions_context", keep_context=2) == [1, 2, 3]
+
+
+def test_context_does_not_keep_frames_after_an_intervention():
+    """The window is a forward look-ahead: it captures the approach to a
+    takeover, not the recovery after it."""
+    cs = [0, 1, 0, 0, 0]
+    kept = _keep_mask(cs, "interventions_context", keep_context=2)
+    assert kept == [0, 1]
+
+
+def test_context_zero_still_keeps_the_frame_immediately_before():
+    """max(1, keep_context) means 0 is not silently 'interventions only'."""
+    cs = [0, 0, 1]
+    assert _keep_mask(cs, "interventions_context", keep_context=0) == [1, 2]
+
+
+def test_context_window_is_clamped_at_the_episode_end():
+    """A window running past the last frame must not raise or wrap."""
+    cs = [0, 0, 0]
+    assert _keep_mask(cs, "interventions_context", keep_context=100) == []
+
+
+def test_context_spans_two_separate_takeovers():
+    cs = [0, 0, 1, 0, 0, 0, 1, 0]
+    kept = _keep_mask(cs, "interventions_context", keep_context=1)
+    assert kept == [1, 2, 5, 6]
+
+
+def test_context_keeps_a_fully_human_episode_intact():
+    assert _keep_mask([1] * 5, "interventions_context", keep_context=3) == list(
+        range(5)
+    )


### PR DESCRIPTION
> **Stacked on #6** — this branch is based on it, so the diff includes its commits until it merges. The `rd infer` changes proper are the last two commits.

## Summary

Adds `rd infer`, a local inference loop for deploying a trained policy on the robot host, with an optional **HG-DAgger interactive-correction mode** (`--intervene`): the policy runs autonomously, the operator grabs a leader arm the moment it starts to fail, corrects, and hands back — and the whole rollout is recorded as **one episode** with a per-frame `control_source` flag (consumed by the convert/shardify plumbing from #6). Follows the ABC recipe: record whole rollouts and mix/upweight corrections at train time, rather than training on interventions alone (see `docs/guide/recovery.md`).

### Why a new command instead of extending `rd serve`

`rd serve` is a remote policy server (chiral protocol): fire-and-forget streaming, leaders off, hard-estop on disconnect. HG-DAgger needs a per-step rendezvous between observation, action, and takeover state, plus powered leader arms — a different control topology. So the loop lives in a new `raiden/inference.py` hosting the model in-process behind a small `ModelBridge` ABC (`load` / `reset` / `predict`), while reusing `RaidenPolicyServer`'s cameras, depth, proprio, and motor control. The hooks added to `server.py` are default-off, so `rd serve` behavior is unchanged.

## Design highlights

- **Instant, seam-free takeover** — during autonomy the powered leaders shadow the followers' *measured* pose, so pressing a trigger hands you the arm exactly where it is; the correction is a joint-space delta (leader and follower are kinematically identical YAM arms), giving a zero seam by construction. Handback re-observes and re-predicts from the pose you left.
- **Bumpless gripper clutch** — the leader trigger is unmotorized and can't be shadowed; the policy's grip command is held until your trigger crosses it, then tracks absolutely.
- **Safe shutdown ordering** — Ctrl+C homes and de-energises the arms **before** the heavy save (SVO2 flush + `np.savez_compressed`); the reverse order starves the 100–250 Hz motor threads past the DM4310 watchdog and drops CAN mid-motion.
- **Recording shares the live ZED handles** — one camera feeds the policy and records SVO2 simultaneously; recording toggles quiesce the grab loop first (a concurrent `grab()` + `enable_recording()` deadlocks the ZED SDK).
- **Single leader-bus owner** — all leader reads/writes stay on one input thread; the policy-runaway estop path stops that thread before commanding the leaders.
- The per-step joint-delta limit (`--max-joint-delta`) applies in **policy mode only** — a deliberate human correction is not a fault.
- Action convention is left-then-right (`[left(6), l_grip, right(6), r_grip]`), matching `rd serve` and `ee_pose` IK output.

### ❓ Question for maintainers: leader trigger calibration

On our rig the leader trigger's physical throw saturates a few percent short of the passive encoder's hardcoded range, so a full squeeze only drives the gripper command down to **~0.04 instead of 0.0** — the follower never fully closes, holding a visible gap and dropping small parts. That is invisible in teleop but bites in HG-DAgger, where a takeover exists precisely to fix a failed grasp.

`_grip_clutch` therefore snaps a trigger within `_GRIP_FULL_CLOSE_SNAP` (0.05) of the bottom to a complete close. **It is deliberately confined to the takeover path**, not the shared `YAMLeaderRobot.get_info()` where it would also change `rd teleop` / `rd record` for every user based on our rig's calibration.

If your triggers reach a true full squeeze, this snap is a harmless no-op on the bottom 5% and you may prefer to drop it — happy to remove it or make it a flag. Worth confirming on your hardware either way, since the underlying saturation would affect teleop grasps too.

## Usage

```bash
rd infer --bridge my_model.bridge:MyBridge --ckpt-path /path/to/ckpt \
         --intervene --dagger-task box_fold_dagger_r1 --dagger-instruction "fold the box flap"
```

Full operator guide (takeover loop, round organization for the 80:10:10 mix, writing a `ModelBridge`): `docs/guide/recovery.md`.

## Status / test plan

`tests/test_controller.py` (new) covers the takeover control logic hardware-free — 9 tests over `_grip_clutch` and `joint_delta_takeover`: the clutch holds the policy's grip until the passive trigger crosses it, never moves the gripper in an unintended direction at takeover, latches through a reversal, reaches a full close via the snap, and `joint_delta_takeover` is checked for the zero-delta takeover edge and for an un-grabbed arm holding its grip. This is the repo's first `tests/` directory; no test job exists in CI yet, so they run locally via `uv run pytest tests/ -v`.

⚠️ **Draft.** The offline logic is reviewed and the data contract with convert/shardify is covered by the tests referenced in #6, but the hardware loop needs on-robot validation before this is merge-ready:

- [ ] takeover / handback seam (no jump) in `joint` and `ee_pose` modes
- [ ] leader shadow tracking + gripper clutch feel
- [ ] Ctrl+C ordering: home → de-energise → save, arms never go limp
- [ ] SVO2 start/stop against live grab loops (no deadlock, no dropped frames)
- [ ] runaway-delta estop path with the leader input thread active
- [ ] recorded episode round-trips through `rd convert` / `rd shardify --keep interventions`

`ruff format --check` + `ruff check` clean; `mkdocs build --strict` clean with the docs-CI dependency set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
